### PR TITLE
Added FlakyTestAttribute and started to tag the first flaky tests

### DIFF
--- a/src/Tailviewer.AcceptanceTests/BusinessLogic/DataSources/SingleDataSourceRealTest.cs
+++ b/src/Tailviewer.AcceptanceTests/BusinessLogic/DataSources/SingleDataSourceRealTest.cs
@@ -79,7 +79,7 @@ namespace Tailviewer.AcceptanceTests.BusinessLogic.DataSources
 		}
 
 		[Test]
-		[LocalTest("This test is wonky and needs to be rewritten")]
+		[FlakyTest(3)]
 		[Description("Verifies that the levels are counted correctly")]
 		public void TestLevelCount1()
 		{

--- a/src/Tailviewer.AcceptanceTests/SingleApplicationHelperTest.cs
+++ b/src/Tailviewer.AcceptanceTests/SingleApplicationHelperTest.cs
@@ -10,7 +10,7 @@ namespace Tailviewer.AcceptanceTests
 	public sealed class SingleApplicationHelperTest
 	{
 		[Test]
-		[LocalTest("This test fails 50% of the time and is thus unsuited to run on AppVeyor until it's fixed")]
+		[FlakyTest(3)]
 		public void TestOpenFile1()
 		{
 			using (var mutex = SingleApplicationHelper.AcquireMutex())
@@ -25,7 +25,7 @@ namespace Tailviewer.AcceptanceTests
 		}
 
 		[Test]
-		[LocalTest("This test fails 50% of the time and is thus unsuited to run on AppVeyor until it's fixed")]
+		[FlakyTest(3)]
 		public void TestBringToFront()
 		{
 			using (var mutex = SingleApplicationHelper.AcquireMutex(TimeSpan.FromSeconds(1)))

--- a/src/Tailviewer.Test/FlakyTestAttribute.cs
+++ b/src/Tailviewer.Test/FlakyTestAttribute.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Commands;
+
+namespace Tailviewer.Test
+{
+	/// <summary>
+	///     This attribute marks a flaky test which should be retried on failure.
+	///     This includes tests which fail not due to an assertion failure, but any random
+	///     exception (including those which are thrown by FluentAssertion failures).
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Method)]
+	public sealed class FlakyTestAttribute
+		: Attribute
+			, IRepeatTest
+	{
+		private readonly int _tryCount;
+
+		public FlakyTestAttribute(int tryCount)
+		{
+			if (tryCount < 2)
+				throw new ArgumentException("Running flaky tests less than twice does not make sense!");
+
+			_tryCount = tryCount;
+		}
+
+		#region Implementation of ICommandWrapper
+
+		public TestCommand Wrap(TestCommand command)
+		{
+			return new RetryCommand(command, _tryCount);
+		}
+
+		#endregion
+
+		private sealed class RetryCommand
+			: TestCommand
+		{
+			private readonly TestCommand _command;
+			private readonly int _tryCount;
+
+			public RetryCommand(TestCommand command, int tryCount)
+				: base(command.Test)
+			{
+				_command = command;
+				_tryCount = tryCount;
+			}
+
+			#region Overrides of TestCommand
+
+			public override TestResult Execute(TestExecutionContext context)
+			{
+				for (int i = 0; i < _tryCount; ++i)
+				{
+					try
+					{
+						context.CurrentResult = _command.Execute(context);
+						if (context.CurrentResult?.ResultState != ResultState.Failure)
+							break;
+					}
+					catch (Exception)
+					{
+						if (i == _tryCount - 1)
+							throw;
+					}
+				}
+
+				return context.CurrentResult;
+			}
+
+			#endregion
+		}
+	}
+}

--- a/src/Tailviewer.Test/Tailviewer.Test.csproj
+++ b/src/Tailviewer.Test/Tailviewer.Test.csproj
@@ -178,6 +178,7 @@
     <Compile Include="ChangelogTest.cs" />
     <Compile Include="DataSourceIdTest.cs" />
     <Compile Include="BusinessLogic\Highlighters\HighlighterIdTest.cs" />
+    <Compile Include="FlakyTestAttribute.cs" />
     <Compile Include="IssueAttribute.cs" />
     <Compile Include="EnhancementAttribute.cs" />
     <Compile Include="FileExTest.cs" />


### PR DESCRIPTION
This attribute actually does what RetryAttribute promises, but fails to keep: It retries the test on failure, including when the test throws an exception.