### PR TITLE
Implemented Clear Screen and Show All #215

### DIFF
--- a/src/Tailviewer.AcceptanceTests/BusinessLogic/DataSources/SingleDataSourceAcceptanceTest.cs
+++ b/src/Tailviewer.AcceptanceTests/BusinessLogic/DataSources/SingleDataSourceAcceptanceTest.cs
@@ -62,6 +62,8 @@ namespace Tailviewer.AcceptanceTests.BusinessLogic.DataSources
 							"Because this line belongs to the previous log entry and thus is marked as fatal as well");
 				lines[5].LogEntryIndex.Should().Be(lines[4].LogEntryIndex);
 
+				_scheduler.RunOnce();
+
 				dataSource.DebugCount.Should().Be(1);
 				dataSource.InfoCount.Should().Be(1);
 				dataSource.WarningCount.Should().Be(1);

--- a/src/Tailviewer.AcceptanceTests/BusinessLogic/DataSources/SingleDataSourceRealTest.cs
+++ b/src/Tailviewer.AcceptanceTests/BusinessLogic/DataSources/SingleDataSourceRealTest.cs
@@ -85,7 +85,7 @@ namespace Tailviewer.AcceptanceTests.BusinessLogic.DataSources
 		{
 			_dataSource.FilteredLogFile.Property(x => x.EndOfSourceReached).ShouldAfter(TimeSpan.FromSeconds(5)).BeTrue();
 
-			_dataSource.TotalCount.Should().Be(165342);
+			_dataSource.Property(x => x.TotalCount).ShouldEventually().Be(165342);
 			_dataSource.DebugCount.Should().Be(165337);
 			_dataSource.InfoCount.Should().Be(5);
 			_dataSource.WarningCount.Should().Be(0);

--- a/src/Tailviewer.AcceptanceTests/Ui/ViewModels/SingleDataSourceViewModelTest.cs
+++ b/src/Tailviewer.AcceptanceTests/Ui/ViewModels/SingleDataSourceViewModelTest.cs
@@ -108,5 +108,29 @@ namespace Tailviewer.AcceptanceTests.Ui.ViewModels
 				monitor.Should().NotRaisePropertyChangeFor(x => x.CanBeRemoved);
 			}
 		}
+
+		[Test]
+		[Issue("https://github.com/Kittyfisto/Tailviewer/issues/215")]
+		public void TestClearAllShowAll()
+		{
+			var dataSource = new Mock<ISingleDataSource>();
+			var model = new SingleDataSourceViewModel(dataSource.Object, new Mock<IActionCenter>().Object);
+
+			model.ScreenCleared.Should().BeFalse();
+
+			model.ClearScreenCommand.Should().NotBeNull();
+			model.ClearScreenCommand.CanExecute(null).Should().BeTrue("because the screen can always be cleared");
+			model.ShowAllCommand.Should().NotBeNull();
+			model.ShowAllCommand.CanExecute(null).Should().BeFalse("because the screen hasn't been cleared so nothing needs to be shown again");
+			model.ClearScreenCommand.Execute(null);
+			dataSource.Verify(x => x.ClearScreen(), Times.Once);
+
+			model.ShowAllCommand.Should().NotBeNull();
+			model.ShowAllCommand.CanExecute(null).Should().BeTrue("because the screen has been cleared and thus everything may be shown again");
+			model.ShowAllCommand.Execute(null);
+			dataSource.Verify(x => x.ShowAll(), Times.Once);
+
+			model.ShowAllCommand.CanExecute(null).Should().BeFalse("because everything has been shown again and thus nothing further can be shown");
+		}
 	}
 }

--- a/src/Tailviewer.Core/Filters/EmptyLogLineFilter.cs
+++ b/src/Tailviewer.Core/Filters/EmptyLogLineFilter.cs
@@ -9,7 +9,7 @@ namespace Tailviewer.Core.Filters
 	/// (or only have whitespace characters).
 	/// </summary>
 	public sealed class EmptyLogLineFilter
-		: ILogLineFilter
+		: ILogEntryFilter
 	{
 		/// <inheritdoc />
 		public bool PassesFilter(LogLine logLine)
@@ -24,5 +24,21 @@ namespace Tailviewer.Core.Filters
 		{
 			return new List<LogLineMatch>();
 		}
+
+		#region Implementation of ILogEntryFilter
+
+		/// <inheritdoc />
+		public bool PassesFilter(IEnumerable<LogLine> logEntry)
+		{
+			throw new System.NotImplementedException();
+		}
+
+		/// <inheritdoc />
+		public void Match(LogLine line, List<LogLineMatch> matches)
+		{
+			throw new System.NotImplementedException();
+		}
+
+		#endregion
 	}
 }

--- a/src/Tailviewer.Core/Filters/Filter.cs
+++ b/src/Tailviewer.Core/Filters/Filter.cs
@@ -47,6 +47,17 @@ namespace Tailviewer.Core.Filters
 		}
 
 		/// <summary>
+		///     Creates a new <see cref="ILogLineFilter"/> from the given values.
+		/// </summary>
+		/// <param name="filters"></param>
+		/// <returns></returns>
+		public static ILogLineFilter Create(IEnumerable<ILogLineFilter> filters)
+		{
+			var tmp = filters.Where(x => x != null).Select(x => (ILogEntryFilter)x).ToList();
+			return Create(tmp);
+		}
+
+		/// <summary>
 		///     Creates a new <see cref="ILogEntryFilter" /> from the given values.
 		/// </summary>
 		/// <param name="filters"></param>
@@ -56,9 +67,13 @@ namespace Tailviewer.Core.Filters
 			var tmp = filters.Where(x => x != null).ToList();
 			if (tmp.Count == 0)
 				return null;
-
 			if (tmp.Count == 1)
-				return tmp[index: 0];
+			{
+				var filter = tmp[0];
+				if (filter is NoFilter)
+					return null;
+				return filter;
+			}
 			return new AndFilter(tmp);
 		}
 
@@ -105,6 +120,18 @@ namespace Tailviewer.Core.Filters
 		}
 
 		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="levels"></param>
+		/// <returns></returns>
+		public static ILogEntryFilter Create(LevelFlags levels)
+		{
+			if (levels == LevelFlags.All)
+				return null;
+			return new LevelFilter(levels);
+		}
+
+		/// <summary>
 		///     Creates a new <see cref="ILogEntryFilter" /> from the given values.
 		/// </summary>
 		/// <param name="levelFilter"></param>
@@ -112,10 +139,10 @@ namespace Tailviewer.Core.Filters
 		/// <param name="orFilters"></param>
 		/// <returns></returns>
 		public static ILogEntryFilter Create(LevelFlags levelFilter,
-			IEnumerable<ILogEntryFilter> andFilters = null,
+			IEnumerable<ILogEntryFilter> andFilters,
 			IEnumerable<ILogEntryFilter> orFilters = null)
 		{
-			var filters = new List<ILogEntryFilter> {new LevelFilter(levelFilter)};
+			var filters = new List<ILogEntryFilter> {Create(levelFilter)};
 			if (andFilters != null)
 				filters.AddRange(andFilters);
 			return Create(filters);
@@ -138,6 +165,22 @@ namespace Tailviewer.Core.Filters
 			if (additionalFilters != null)
 				filters.AddRange(additionalFilters);
 			return Create(filters);
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="logEntryFilter"></param>
+		/// <returns></returns>
+		public static bool IsFilter(ILogLineFilter logEntryFilter)
+		{
+			if (logEntryFilter == null)
+				return false;
+
+			if (logEntryFilter is NoFilter)
+				return false;
+
+			return true;
 		}
 	}
 }

--- a/src/Tailviewer.Core/Filters/RangeFilter.cs
+++ b/src/Tailviewer.Core/Filters/RangeFilter.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using Tailviewer.BusinessLogic.Filters;
+using Tailviewer.BusinessLogic.LogFiles;
+
+namespace Tailviewer.Core.Filters
+{
+	/// <summary>
+	/// Responsible for filtering a range of log entries based on their <see cref="LogLine.LineIndex"/>.
+	/// </summary>
+	public sealed class RangeFilter
+		: ILogEntryFilter
+	{
+		private readonly LogFileSection _filteredSection;
+
+		/// <summary>
+		/// Initializes this range filter.
+		/// </summary>
+		/// <param name="filteredSection"></param>
+		public RangeFilter(LogFileSection filteredSection)
+		{
+			_filteredSection = filteredSection;
+		}
+
+		#region Implementation of ILogLineFilter
+
+		/// <inheritdoc />
+		public bool PassesFilter(LogLine logLine)
+		{
+			var index = logLine.LineIndex;
+			return !_filteredSection.Contains(index);
+		}
+		
+		/// <inheritdoc />
+		public List<LogLineMatch> Match(LogLine line)
+		{
+			return null;
+		}
+
+		#endregion
+
+		#region Implementation of ILogEntryFilter
+
+		/// <inheritdoc />
+		public bool PassesFilter(IEnumerable<LogLine> logEntry)
+		{
+			foreach (var line in logEntry)
+			{
+				if (!PassesFilter(line))
+					return false;
+			}
+
+			return true;
+		}
+
+		/// <inheritdoc />
+		public void Match(LogLine line, List<LogLineMatch> matches)
+		{}
+
+		#endregion
+	}
+}

--- a/src/Tailviewer.Core/Tailviewer.Core.csproj
+++ b/src/Tailviewer.Core/Tailviewer.Core.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Filters\ExpressionEngine\ContainsStringExpression.cs" />
     <Compile Include="Filters\ExpressionEngine\DateTimeInterval.cs" />
     <Compile Include="Filters\ExpressionEngine\DateTimeLiteral.cs" />
+    <Compile Include="Filters\RangeFilter.cs" />
     <Compile Include="LogFiles\EventLogFile.cs" />
     <Compile Include="LogFiles\Issues\LogFileIssue.cs" />
     <Compile Include="LogFiles\LogFileFormats.cs" />

--- a/src/Tailviewer.Test/BusinessLogic/DataSources/SingleDataSourceTest.cs
+++ b/src/Tailviewer.Test/BusinessLogic/DataSources/SingleDataSourceTest.cs
@@ -242,6 +242,55 @@ namespace Tailviewer.Test.BusinessLogic.DataSources
 			}
 		}
 
+		[Test]
+		[Description("Verifies that ClearScreen() filters all entries of the log file")]
+		[Issue("https://github.com/Kittyfisto/Tailviewer/issues/215")]
+		public void TestClearScreen()
+		{
+			var settings = CreateDataSource();
+			var logFile = new InMemoryLogFile();
+			logFile.AddEntry("Foo");
+			logFile.AddEntry("Bar");
+			using (var dataSource = new SingleDataSource(_scheduler, settings, logFile, TimeSpan.Zero))
+			{
+				_scheduler.RunOnce();
+				dataSource.FilteredLogFile.Count.Should().Be(2);
+
+				dataSource.ClearScreen();
+				_scheduler.RunOnce();
+				dataSource.FilteredLogFile.Count.Should().Be(0, "because we've just cleared the screen");
+
+
+				logFile.AddEntry("Hello!");
+				_scheduler.Run(2);
+				dataSource.FilteredLogFile.Count.Should().Be(1, "because newer log entries should still appear");
+				dataSource.FilteredLogFile.GetLine(0).Message.Should().Be("Hello!");
+			}
+		}
+
+		[Test]
+		[Description("Verifies that ShowAll() shows all entries of the log file again")]
+		[Issue("https://github.com/Kittyfisto/Tailviewer/issues/215")]
+		public void TestClearScreenShowAll()
+		{
+			var settings = CreateDataSource();
+			var logFile = new InMemoryLogFile();
+			logFile.AddEntry("Foo");
+			logFile.AddEntry("Bar");
+			using (var dataSource = new SingleDataSource(_scheduler, settings, logFile, TimeSpan.Zero))
+			{
+				_scheduler.RunOnce();
+
+				dataSource.ClearScreen();
+				_scheduler.RunOnce();
+				dataSource.FilteredLogFile.Count.Should().Be(0, "because we've just cleared the screen");
+
+				dataSource.ShowAll();
+				_scheduler.RunOnce();
+				dataSource.FilteredLogFile.Count.Should().Be(2, "because we've just shown everything again");
+			}
+		}
+
 		private DataSource CreateDataSource()
 		{
 			return new DataSource("ffff") {Id = DataSourceId.CreateNew()};

--- a/src/Tailviewer.Test/BusinessLogic/Filters/RangeFilterTest.cs
+++ b/src/Tailviewer.Test/BusinessLogic/Filters/RangeFilterTest.cs
@@ -1,0 +1,28 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Tailviewer.BusinessLogic;
+using Tailviewer.BusinessLogic.LogFiles;
+using Tailviewer.Core.Filters;
+
+namespace Tailviewer.Test.BusinessLogic.Filters
+{
+	[TestFixture]
+	public sealed class RangeFilterTest
+	{
+		[Test]
+		public void Test()
+		{
+			var filter = new RangeFilter(new LogFileSection(42, 101));
+			filter.PassesFilter(CreateLine(0)).Should().BeTrue();
+			filter.PassesFilter(CreateLine(41)).Should().BeTrue();
+			filter.PassesFilter(CreateLine(42)).Should().BeFalse();
+			filter.PassesFilter(CreateLine(142)).Should().BeFalse();
+			filter.PassesFilter(CreateLine(143)).Should().BeTrue();
+		}
+
+		private static LogLine CreateLine(LogLineIndex lineIndex)
+		{
+			return new LogLine(lineIndex, 0, "", LevelFlags.None, null);
+		}
+	}
+}

--- a/src/Tailviewer.Test/Tailviewer.Test.csproj
+++ b/src/Tailviewer.Test/Tailviewer.Test.csproj
@@ -115,6 +115,7 @@
     <Compile Include="BusinessLogic\Filters\LevelFilterTest.cs" />
     <Compile Include="BusinessLogic\Filters\NoFilterTest.cs" />
     <Compile Include="BusinessLogic\Filters\OrFilterTest.cs" />
+    <Compile Include="BusinessLogic\Filters\RangeFilterTest.cs" />
     <Compile Include="BusinessLogic\Highlighters\HighlighterTest.cs" />
     <Compile Include="BusinessLogic\LevelFlagsTest.cs" />
     <Compile Include="BusinessLogic\LogDataCacheTest.cs" />

--- a/src/Tailviewer/BusinessLogic/DataSources/FolderDataSource.cs
+++ b/src/Tailviewer/BusinessLogic/DataSources/FolderDataSource.cs
@@ -265,6 +265,23 @@ namespace Tailviewer.BusinessLogic.DataSources
 			}
 		}
 
+		public bool ScreenCleared
+		{
+			get { return _mergedDataSource.ScreenCleared; }
+		}
+
+		public void ClearScreen()
+		{
+			_mergedDataSource.ClearScreen();
+			_filteredLogFileProxy.InnerLogFile = _mergedDataSource.FilteredLogFile;
+		}
+
+		public void ShowAll()
+		{
+			_mergedDataSource.ShowAll();
+			_filteredLogFileProxy.InnerLogFile = _mergedDataSource.FilteredLogFile;
+		}
+
 		public DataSourceId Id
 		{
 			get { return _mergedDataSource.Id; }

--- a/src/Tailviewer/BusinessLogic/DataSources/IDataSource.cs
+++ b/src/Tailviewer/BusinessLogic/DataSources/IDataSource.cs
@@ -79,6 +79,10 @@ namespace Tailviewer.BusinessLogic.DataSources
 		bool ColorByLevel { get; set; }
 		bool HideEmptyLines { get; set; }
 		bool IsSingleLine { get; set; }
+		bool ScreenCleared { get; }
+		void ClearScreen();
+		void ShowAll();
+
 		DataSourceId Id { get; }
 		DataSourceId ParentId { get; }
 

--- a/src/Tailviewer/Ui/Controls/LogView/LogViewerControl.xaml
+++ b/src/Tailviewer/Ui/Controls/LogView/LogViewerControl.xaml
@@ -153,6 +153,23 @@
                                     ToolTip="Treat every single line as a separate log entry"
                                     Content="Single line" />
 
+                                <controls:FlatButton 
+                                    Margin="0"
+                                    Padding="4"
+                                    x:Name="PART_CLS"
+                                    Command="{Binding DataSource.ClearScreenCommand}"
+                                    Content="Clear Screen"
+                                    ToolTip="Hides all log current entries of the data source. New log entries will still be shown once they are added to the data source."/>
+
+                                <controls:FlatButton 
+                                    Margin="0"
+                                    Padding="4"
+                                    x:Name="PART_ShowAll"
+                                    Command="{Binding DataSource.ShowAllCommand}"
+                                    IsEnabled="{Binding DataSource.ScreenCleared}"
+                                    Content="Show All"
+                                    ToolTip="Shows all log entries that were previously cleared again"/>
+
                             </StackPanel>
                         </controls:MenuItemContentControl>
                     </controls:FlatContextMenu>

--- a/src/Tailviewer/Ui/ViewModels/AbstractDataSourceViewModel.cs
+++ b/src/Tailviewer/Ui/ViewModels/AbstractDataSourceViewModel.cs
@@ -39,6 +39,8 @@ namespace Tailviewer.Ui.ViewModels
 		private int _currentSearchResultIndex;
 		private int _searchResultCount;
 		private double _progress;
+		private readonly DelegateCommand2 _clearScreenCommand;
+		private readonly DelegateCommand2 _showAllCommand;
 
 		#region Find all
 
@@ -59,6 +61,12 @@ namespace Tailviewer.Ui.ViewModels
 			_removeCommand = new DelegateCommand(OnRemoveDataSource);
 			_currentSearchResultIndex = -1;
 
+			_clearScreenCommand = new DelegateCommand2(ClearScreen);
+
+			_showAllCommand = new DelegateCommand2(ShowAll)
+			{
+				CanBeExecuted = false
+			};
 		}
 
 		public int NewLogLineCount
@@ -418,6 +426,21 @@ namespace Tailviewer.Ui.ViewModels
 			}
 		}
 
+		public bool ScreenCleared
+		{
+			get { return _dataSource.ScreenCleared; }
+		}
+
+		public ICommand ClearScreenCommand
+		{
+			get { return _clearScreenCommand; }
+		}
+
+		public ICommand ShowAllCommand
+		{
+			get { return _showAllCommand; }
+		}
+
 		#region Searches
 
 		public double Progress
@@ -672,6 +695,21 @@ namespace Tailviewer.Ui.ViewModels
 		protected void EmitPropertyChanged([CallerMemberName] string propertyName = null)
 		{
 			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+
+		private void ClearScreen()
+		{
+			_dataSource.ClearScreen();
+
+			EmitPropertyChanged(nameof(ScreenCleared));
+			_showAllCommand.CanBeExecuted = true;
+		}
+
+		private void ShowAll()
+		{
+			_dataSource.ShowAll();
+			EmitPropertyChanged(nameof(ScreenCleared));
+			_showAllCommand.CanBeExecuted = false;
 		}
 	}
 }

--- a/src/Tailviewer/Ui/ViewModels/IDataSourceViewModel.cs
+++ b/src/Tailviewer/Ui/ViewModels/IDataSourceViewModel.cs
@@ -7,7 +7,6 @@ using Tailviewer.Archiver.Plugins.Description;
 using Tailviewer.BusinessLogic;
 using Tailviewer.BusinessLogic.DataSources;
 using Tailviewer.BusinessLogic.Filters;
-using Tailviewer.BusinessLogic.LogFiles;
 
 namespace Tailviewer.Ui.ViewModels
 {
@@ -84,6 +83,24 @@ namespace Tailviewer.Ui.ViewModels
 		bool HideEmptyLines { get; set; }
 
 		bool IsSingleLine { get; set; }
+
+		/// <summary>
+		///     When set to true, all current log entries will be filtered out.
+		///     Newer log entries will still appear.
+		///     When set to false, all log entries (that are not otherwise filtered) appear again.
+		/// </summary>
+		bool ScreenCleared { get; }
+
+		/// <summary>
+		/// Clears all log entries currently part of the data source.
+		/// Future log entries will be shown once they become available.
+		/// </summary>
+		ICommand ClearScreenCommand { get; }
+
+		/// <summary>
+		/// Sets <see cref="ScreenCleared"/> to false.
+		/// </summary>
+		ICommand ShowAllCommand { get; }
 
 		double Progress { get; }
 


### PR DESCRIPTION
Fixes #215

Changes proposed in this pull request:
- Implement Clear Screen & Show All Buttons
- Clear Screen filters out all log entries currently in the log file
- Log entries written to the log file *after* the Clear Screen button has been pressed, still appear
- Show All removes the filter applied by the Clear Screen button
- Clear Screen remembers the amount of lines present in the *unfiltered* log file and only displays lines with a higher index than that count, even if the log file is deleted in between. The only way to make those filtered lines appear again is to press Show All
- Pressing Clear Screen a second time is possible and filters any additional log lines if necessary
- The clear screen setting is not persisted between sessions and resets after a tailviewer restart

The feature can be accessed by selecting a log file and then pressing "View" on the top left. "Clear Screen" and "Show All" are the bottom-most buttons on that popup:
![image](https://user-images.githubusercontent.com/11990827/74084137-21126b00-4a6c-11ea-8246-4608e0a9cf2a.png)


Any expected problems concerning backwards compatibility of existing plugins?  
No

Any expected problems concerning backwards compatibility of existing user settings?  
No

Does this break existing user workflows?  
No
