### PR TITLE
Implemented variable tab width

### DIFF
--- a/examples/Tailviewer.LogLevelPlugin/TestData/Example.mylog
+++ b/examples/Tailviewer.LogLevelPlugin/TestData/Example.mylog
@@ -1,7 +1,7 @@
 0 This log file contains lineswith log levels which are not detected by tailviewer by default.
 1 DBG This is a DEBUG level line
-2 ERR This line contains an ERROR
-3 WARN This line contains a WARNING
-4 TRA This line contains a TRACE message
-5 INF This line is of INFORMATIVE nature
-6 FAT This line is really FATal
+ 2 ERR This line contains an ERROR
+  3 WARN This line contains a WARNING
+ 	4 TRA This line contains a TRACE message
+	 	5 INF This line is of INFORMATIVE nature
+ 6 FAT This line is really FATal

--- a/src/Tailviewer.Test/Settings/LogViewerSettingsTest.cs
+++ b/src/Tailviewer.Test/Settings/LogViewerSettingsTest.cs
@@ -52,21 +52,25 @@ namespace Tailviewer.Test.Settings
 			var settings = new LogViewerSettings();
 			settings.LinesScrolledPerWheelTick.Should().Be(2);
 			settings.FontSize.Should().Be(12);
+			settings.TabWidth.Should().Be(4);
 		}
 
 		[Test]
-		public void TestClone([Values(1, 2, 3, 4)] int linesScrolledPerWheelTick,
-		                      [Values(1, 2, 3)] int fontSize)
+		public void TestClone([Values(1, 2)] int linesScrolledPerWheelTick,
+		                      [Values(1, 2)] int fontSize,
+		                      [Values(1, 2)] int tabWidth)
 		{
 			var settings = new LogViewerSettings
 			{
 				LinesScrolledPerWheelTick = linesScrolledPerWheelTick,
-				FontSize = fontSize
+				FontSize = fontSize,
+				TabWidth = tabWidth
 			};
 
 			var actualSettings = settings.Clone();
 			actualSettings.LinesScrolledPerWheelTick.Should().Be(linesScrolledPerWheelTick);
 			actualSettings.FontSize.Should().Be(fontSize);
+			actualSettings.TabWidth.Should().Be(tabWidth);
 		}
 
 		[Test]
@@ -91,38 +95,45 @@ namespace Tailviewer.Test.Settings
 				"because when the attribute doesn't appear in the xml content, then its default value shall be restored";
 			settings.LinesScrolledPerWheelTick.Should().Be(2, reason);
 			settings.FontSize.Should().Be(12, reason);
+			settings.TabWidth.Should().Be(4, reason);
 		}
 
 		[Test]
 		[Description("Verifies that upon restoration, invalid values are replaced with defaults")]
 		public void TestRestoreFromInvalidValues([Values(-5, -2, -1, 0)] int linesScrolledPerWheelTick,
-		                                         [Values(-5, -1, 0)] int fontSize)
+		                                         [Values(-5, -1, 0)] int fontSize,
+		                                         [Values(-1, 0)] int tabWidth)
 		{
 			var file = Save(new LogViewerSettings
 			{
 				LinesScrolledPerWheelTick = linesScrolledPerWheelTick,
-				FontSize = fontSize
+				FontSize = fontSize,
+				TabWidth = tabWidth
 			});
 
 			var settings = Restore(file);
 			settings.LinesScrolledPerWheelTick.Should().Be(2, "because restore should simply discard invalid values and restore them to their defaults");
 			settings.FontSize.Should().Be(12);
+			settings.TabWidth.Should().Be(4);
 		}
 
 		[Test]
-		public void TestRoundtrip([Values(1, 2, 5)] int linesScrolledPerWheelTick,
-		                          [Values(1, 20, 40)] int fontSize)
+		public void TestRoundtrip([Values(1, 2)] int linesScrolledPerWheelTick,
+		                          [Values(1, 20)] int fontSize,
+		                          [Values(1, 2)] int tabWidth)
 		{
 			var settings = new LogViewerSettings
 			{
 				LinesScrolledPerWheelTick = linesScrolledPerWheelTick,
-				FontSize = fontSize
+				FontSize = fontSize,
+				TabWidth = tabWidth
 			};
 
 			var actualSettings = Restore(Save(settings));
 			const string reason = "because all values should roundtrip perfectly";
 			actualSettings.LinesScrolledPerWheelTick.Should().Be(linesScrolledPerWheelTick, reason);
 			actualSettings.FontSize.Should().Be(fontSize, reason);
+			actualSettings.TabWidth.Should().Be(tabWidth);
 		}
 	}
 }

--- a/src/Tailviewer.Test/Ui/Controls/TextLineTest.cs
+++ b/src/Tailviewer.Test/Ui/Controls/TextLineTest.cs
@@ -286,5 +286,24 @@ namespace Tailviewer.Test.Ui.Controls
 			var textLine = new TextLine(new LogLine(1, message.ToString(), LevelFlags.None, null), _hovered, _selected, true);
 			textLine.Segments.Count.Should().BeGreaterThan(1, "because this very long line should've been split up into multiple messages");
 		}
+
+		[Test]
+		public void TestReplaceTabsWithSpaces()
+		{
+			string replace(string input, int tabWidth)
+			{
+				var builder = new StringBuilder(input);
+				TextLine.ReplaceTabsWithSpaces(builder, tabWidth);
+				return builder.ToString();
+			}
+
+			replace("\t", 4).Should().Be("    ");
+			replace(" \t", 4).Should().Be("    ");
+			replace("a\t", 4).Should().Be("a   ");
+			replace("ab\t", 4).Should().Be("ab  ");
+			replace("abc\t", 4).Should().Be("abc ");
+			replace("abcd\t", 4).Should().Be("abcd    ");
+			replace("a\t\t", 2).Should().Be("a   ");
+		}
 	}
 }

--- a/src/Tailviewer/Settings/ILogViewerSettings.cs
+++ b/src/Tailviewer/Settings/ILogViewerSettings.cs
@@ -1,5 +1,4 @@
-﻿
-namespace Tailviewer.Settings
+﻿namespace Tailviewer.Settings
 {
 	/// <summary>
 	///     "Global" configuration of the log viewer.
@@ -15,5 +14,10 @@ namespace Tailviewer.Settings
 		/// <summary>
 		/// </summary>
 		int FontSize { get; set; }
+
+		/// <summary>
+		///     The width of a tab-character expressed in number of spaces.
+		/// </summary>
+		int TabWidth { get; set; }
 	}
 }

--- a/src/Tailviewer/Settings/LogViewerSettings.cs
+++ b/src/Tailviewer/Settings/LogViewerSettings.cs
@@ -14,16 +14,19 @@ namespace Tailviewer.Settings
 	{
 		public const int DefaultLinesScrolledPerWheelTick = 2;
 		public const int DefaultFontSize = 12;
+		public const int DefaultTabWidth = 4;
 
 		private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
 		private int _linesScrolledPerWheelTick;
 		private int _fontSize;
+		private int _tabWidth;
 
 		public LogViewerSettings()
 		{
 			_linesScrolledPerWheelTick = DefaultLinesScrolledPerWheelTick;
 			_fontSize = DefaultFontSize;
+			_tabWidth = DefaultTabWidth;
 		}
 
 		public int LinesScrolledPerWheelTick
@@ -38,10 +41,17 @@ namespace Tailviewer.Settings
 			set { _fontSize = value; }
 		}
 
+		public int TabWidth
+		{
+			get { return _tabWidth; }
+			set { _tabWidth = value; }
+		}
+
 		public void Save(XmlWriter writer)
 		{
 			writer.WriteAttributeInt("linesscrolledperwheeltick", _linesScrolledPerWheelTick);
 			writer.WriteAttributeInt("fontsize", _fontSize);
+			writer.WriteAttributeInt("tabwidth", _tabWidth);
 		}
 
 		public void Restore(XmlReader reader)
@@ -59,6 +69,13 @@ namespace Tailviewer.Settings
 				Log.WarnFormat("Attribute 'fontsize' must be 1 or greater, restoring value to default...");
 				_fontSize = DefaultFontSize;
 			}
+
+			reader.ReadAttributeAsInt("tabwidth", Log, DefaultTabWidth, out _tabWidth);
+			if (_tabWidth < 1)
+			{
+				Log.WarnFormat("Attribute 'tabwidth' must be 1 or greater, restoring value to default...");
+				_tabWidth = DefaultTabWidth;
+			}
 		}
 
 		[Pure]
@@ -67,7 +84,8 @@ namespace Tailviewer.Settings
 			return new LogViewerSettings
 			{
 				LinesScrolledPerWheelTick = LinesScrolledPerWheelTick,
-				FontSize = FontSize
+				FontSize = FontSize,
+				TabWidth = TabWidth
 			};
 		}
 

--- a/src/Tailviewer/Settings/TextSettings.cs
+++ b/src/Tailviewer/Settings/TextSettings.cs
@@ -22,9 +22,10 @@ namespace Tailviewer.Settings
 		public readonly double LineNumberSpacing;
 		public readonly Typeface Typeface;
 		public readonly double GlyphWidth;
-		public readonly double TabWidth;
+		public readonly int TabWidth;
 
-		public TextSettings(int fontSize = 12)
+		public TextSettings(int fontSize = LogViewerSettings.DefaultFontSize,
+		                    int tabWidth = LogViewerSettings.DefaultTabWidth)
 		{
 			FontSize = fontSize;
 			LineSpacing = 3;
@@ -34,17 +35,11 @@ namespace Tailviewer.Settings
 			FontFamily family = PickFontFamily();
 			Typeface = new Typeface(family, FontStyles.Normal, FontWeights.Normal, FontStretches.Normal);
 
-			GlyphTypeface test;
-			Typeface.TryGetGlyphTypeface(out test);
+			Typeface.TryGetGlyphTypeface(out var test);
 
 			ushort glyphIndex = test.CharacterToGlyphMap[' '];
 			GlyphWidth = test.AdvanceWidths[glyphIndex]*FontSize;
-			TabWidth = new FormattedText("s\t", CultureInfo.CurrentUICulture,
-			                             FlowDirection.LeftToRight,
-			                             Typeface,
-			                             FontSize,
-			                             Brushes.Black,
-			                             1.25).Width;
+			TabWidth = tabWidth;
 		}
 
 		#region Overrides of Object

--- a/src/Tailviewer/Ui/Controls/LogView/LogEntryListView.cs
+++ b/src/Tailviewer/Ui/Controls/LogView/LogEntryListView.cs
@@ -113,7 +113,7 @@ namespace Tailviewer.Ui.Controls.LogView
 
 		public LogEntryListView()
 		{
-			var textSettings = TextSettings.Default;
+			var textSettings = new TextSettings();
 
 			RowDefinitions.Add(new RowDefinition { Height = new GridLength(value: 1, type: GridUnitType.Star) });
 			RowDefinitions.Add(new RowDefinition { Height = new GridLength(value: 1, type: GridUnitType.Auto) });
@@ -641,7 +641,9 @@ namespace Tailviewer.Ui.Controls.LogView
 
 		private void OnSettingsChanged(ILogViewerSettings settings)
 		{
-			ChangeTextSettings(settings != null ? new TextSettings(settings.FontSize) : TextSettings.Default);
+			ChangeTextSettings(settings != null
+				                   ? new TextSettings(settings.FontSize, settings.TabWidth)
+				                   : TextSettings.Default);
 		}
 
 		private void ChangeTextSettings(TextSettings textSettings)

--- a/src/Tailviewer/Ui/Controls/LogView/TextLine.cs
+++ b/src/Tailviewer/Ui/Controls/LogView/TextLine.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Text;
 using System.Windows;
 using System.Windows.Media;
 using Tailviewer.BusinessLogic;
@@ -207,7 +208,7 @@ namespace Tailviewer.Ui.Controls.LogView
 			{
 				_segments.Clear();
 
-				string message = _logLine.Message ?? string.Empty;
+				string message = CreateMessage(_logLine.Message);
 				Brush highlightedBrush = TextHelper.HighlightedForegroundBrush;
 				var searchResults = _searchResults;
 				if (searchResults != null)
@@ -247,6 +248,13 @@ namespace Tailviewer.Ui.Controls.LogView
 				}
 				_lastForegroundBrush = regularForegroundBrush;
 			}
+		}
+
+		private string CreateMessage(string logLineMessage)
+		{
+			var builder = new StringBuilder(logLineMessage ?? string.Empty);
+			ReplaceTabsWithSpaces(builder, _textSettings.TabWidth);
+			return builder.ToString();
 		}
 
 		private void AddSegmentsFrom(string message, Brush brush, bool isRegular)
@@ -326,6 +334,26 @@ namespace Tailviewer.Ui.Controls.LogView
 
 			var isVisible = !(xMax < visibleXMin || xMin > visibleXMax);
 			return isVisible;
+		}
+
+		public static void ReplaceTabsWithSpaces(StringBuilder builder, int tabWidth)
+		{
+			for (int i = 0; i < builder.Length;)
+			{
+				if (builder[i] == '\t')
+				{
+					var already = i % tabWidth;
+					var remaining = tabWidth - already;
+					builder.Remove(i, 1);
+					builder.Insert(i, " ", remaining);
+
+					i += remaining;
+				}
+				else
+				{
+					++i;
+				}
+			}
 		}
 	}
 }

--- a/src/Tailviewer/Ui/Controls/MainPanel/Settings/SettingsControl.xaml
+++ b/src/Tailviewer/Ui/Controls/MainPanel/Settings/SettingsControl.xaml
@@ -59,6 +59,8 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="5" />
                             <RowDefinition Height="Auto" />
+                            <RowDefinition Height="5" />
+                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="170" />
@@ -89,6 +91,23 @@
                         <controls:EditorTextBox Grid.Column="1" Grid.Row="2">
                             <controls:EditorTextBox.Text>
                                 <Binding Path="FontSize"
+                                         Mode="TwoWay"
+                                         UpdateSourceTrigger="PropertyChanged">
+                                    <Binding.ValidationRules>
+                                        <tailviewer:Int32RangeRule Minimum="1" Maximum="100" />
+                                    </Binding.ValidationRules>
+                                </Binding>
+                            </controls:EditorTextBox.Text>
+                        </controls:EditorTextBox>
+
+                        <TextBlock Text="Tab Width"
+                                   VerticalAlignment="Center"
+                                   Margin="0,6,6,6"
+                                   Grid.Row="4"
+                                   Grid.Column="0"/>
+                        <controls:EditorTextBox Grid.Column="1" Grid.Row="4">
+                            <controls:EditorTextBox.Text>
+                                <Binding Path="TabWidth"
                                          Mode="TwoWay"
                                          UpdateSourceTrigger="PropertyChanged">
                                     <Binding.ValidationRules>

--- a/src/Tailviewer/Ui/Controls/MainPanel/Settings/SettingsMainPanelViewModel.cs
+++ b/src/Tailviewer/Ui/Controls/MainPanel/Settings/SettingsMainPanelViewModel.cs
@@ -178,6 +178,21 @@ namespace Tailviewer.Ui.Controls.MainPanel.Settings
 				_settings.SaveAsync();
 			}
 		}
+		
+		public int TabWidth
+		{
+			get { return _settings.LogViewer.TabWidth; }
+			set
+			{
+				if (value == _settings.LogViewer.TabWidth)
+					return;
+
+				_settings.LogViewer.TabWidth = value;
+				EmitPropertyChanged();
+
+				_settings.SaveAsync();
+			}
+		}
 
 		public bool AlwaysOnTop
 		{


### PR DESCRIPTION
Tab width can be configured in settings
Tab width is persisted in settings
Tab width defaults to 4 spaces (from previously 1)
Has no effect on scroll area size so in some cases, text may be cut off

Fixes #232