### PR TITLE
Fixed bug involving searches on log files with tabs #244

### DIFF
--- a/src/Tailviewer.Test/Ui/Controls/TextLineTest.cs
+++ b/src/Tailviewer.Test/Ui/Controls/TextLineTest.cs
@@ -125,9 +125,33 @@ namespace Tailviewer.Test.Ui.Controls
 				SearchResults = results
 			};
 
-			textLine.Segments.Count().Should().Be(2);
+			textLine.Segments.Count.Should().Be(2);
 			textLine.Segments.ElementAt(0).Text.Should().Be(".NET Environment: 4.0.30319.");
 			textLine.Segments.ElementAt(1).Text.Should().Be("42000");
+		}
+
+		[Test]
+		[Description("Verifies that highlighting works correct on lines containing tabs")]
+		[Issue("https://github.com/Kittyfisto/Tailviewer/issues/244")]
+		public void TestHighlightTabs()
+		{
+			var results = new SearchResults();
+			var message = "		double tabs, offset by eight";
+			var searchTerm = "tabs";
+			results.Add(new LogMatch(0, new LogLineMatch(message.IndexOf(searchTerm), searchTerm.Length)));
+			const int tabWidth = 4; //< It's important that we run this test with a tabwidth of > 1
+			var textSettings = new TextSettings(tabWidth: tabWidth);
+
+			var textLine = new TextLine(new LogLine(0, 0, message, LevelFlags.Other), _hovered,
+			                            _selected, true, textSettings, new TextBrushes(null))
+			{
+				SearchResults = results
+			};
+
+			textLine.Segments.Count.Should().Be(3);
+			textLine.Segments.ElementAt(0).Text.Should().Be("        double ");
+			textLine.Segments.ElementAt(1).Text.Should().Be("tabs");
+			textLine.Segments.ElementAt(2).Text.Should().Be(", offset by eight");
 		}
 
 		[Test]


### PR DESCRIPTION
The central log viewer would misalign the search-term highlights incorrectly for every line containing tabs. This was caused by the search itself operating on the lines as is and reference sections of the line with respect to the number of characters from the start, e.g. a typical search result would be "index 12, 5 characters long".
However the text display itself would modify the message prior to rendering and effectively expand tab characters by the number of spaces the user has specified. When applying the search result, it would not take this expansion into account and re-use the indices reported by the search *on* the expanded message.
This means that as soon as the user specified a tab width > 1, the search results were misaligned by the number of tabs *left* of the search term, multiplied by the number spaces per tab.

The fix involved simply subdividing the message into its search result constituents first and only then expanding the individual substrings, replacing tabs with spaces.

Fixes #244

Any expected problems concerning backwards compatibility of existing plugins?  
No

Any expected problems concerning backwards compatibility of existing user settings?  
No

Does this break existing user workflows?  
No
