### PR TITLE
Trying to update nuspec to nugets ridiculous standards

### DIFF
--- a/pack.cmd
+++ b/pack.cmd
@@ -1,0 +1,11 @@
+@setlocal
+@echo off
+
+if not defined APPVEYOR_BUILD_VERSION (
+	echo Error: Expected the environment variable APPVEYOR_BUILD_VERSION to be set, but it's not!
+	exit /b -1
+)
+
+nuget pack src\Tailviewer.Api\Tailviewer.Api.nuspec -Version %APPVEYOR_BUILD_VERSION%-beta
+
+endlocal

--- a/src/Tailviewer.Api/Tailviewer.Api.nuspec
+++ b/src/Tailviewer.Api/Tailviewer.Api.nuspec
@@ -2,7 +2,10 @@
 <package >
   <metadata>
     <id>Tailviewer.Api</id>
-    <version>$version$-beta</version>
+    <!-- The version will be overwritten via a commandline parameter in pack.cmd.
+         However if we don't include a placeholder here, then nuget will throw a hissy fit
+         and not produce anything... -->
+    <version>$version$</version>
     <authors>Simon Mießler</authors>
     <owners>Simon Mießler</owners>
     <license type="expression">MIT</license>
@@ -23,7 +26,9 @@
   </metadata>
   <files>
     <file src="..\..\src\Tailviewer\Resources\Tailviewer.png" target="" />
+    <file src="..\..\bin\Tailviewer.Api.dll" target="lib\net45\" />
     <file src="..\..\bin\Tailviewer.Api.pdb" target="lib\net45\" />
+    <file src="..\..\bin\Tailviewer.Api.xml" target="lib\net45\" />
     <file src="..\..\bin\Tailviewer.Core.dll" target="lib\net45\" />
     <file src="..\..\bin\Tailviewer.Core.pdb" target="lib\net45\" />
     <file src="..\..\bin\Tailviewer.Core.xml" target="lib\net45\" />

--- a/src/Tailviewer.Api/Tailviewer.Api.nuspec
+++ b/src/Tailviewer.Api/Tailviewer.Api.nuspec
@@ -5,21 +5,24 @@
     <version>$version$-beta</version>
     <authors>Simon Mießler</authors>
     <owners>Simon Mießler</owners>
-    <licenseUrl>https://github.com/Kittyfisto/Tailviewer/blob/master/LICENSE</licenseUrl>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/Kittyfisto/Tailviewer/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/Kittyfisto/Tailviewer/master/Tailviewer/Resources/Tailviewer.ico</iconUrl>
+    <icon>Tailviewer.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>API to create plugins for Tailviewer, the free log file viewer</description>
     <releaseNotes>Alpha release</releaseNotes>
     <copyright>Copyright 2017</copyright>
     <tags>.NET Tailviewer API SDK logfile</tags>
     <dependencies>
-      <dependency id="log4net" version="2.0.8" />
-      <dependency id="Metrolib" version="0.3.0.135" />
-      <dependency id="System.Threading.Extensions" version="2.0.59" />
+      <group targetFramework=".NETFramework4.5">
+        <dependency id="log4net" version="2.0.8" />
+        <dependency id="Metrolib" version="0.3.0.135" />
+        <dependency id="System.Threading.Extensions" version="2.0.59" />
+      </group>
     </dependencies>
   </metadata>
   <files>
+    <file src="..\..\src\Tailviewer\Resources\Tailviewer.png" target="" />
     <file src="..\..\bin\Tailviewer.Api.pdb" target="lib\net45\" />
     <file src="..\..\bin\Tailviewer.Core.dll" target="lib\net45\" />
     <file src="..\..\bin\Tailviewer.Core.pdb" target="lib\net45\" />


### PR DESCRIPTION
nuget.exe contains a bug where if one specifies the .csproj file, then it will spout nonsense errors about a supposedly missing dependency group:

> Error NU5128: Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder do not have exact matches in the other location. Consult the list of actions below:
> - Add a dependency group for .NETFramework4.5 to the nuspec

Adding said group to the nuspec file did not change anything and the same error occured regardless.  

The solution was to **not** specify the csproj file but to only specify the nuspec file, adding the entries which were previously added automatically from the csproj myself.  

The the process, I moved the call to create the nuget package to a new batch file so that the appveyor jobs won't have to be modified that often.