### PR TITLE
Fixed bug where grouped data source counters were never updated #225

### DIFF
--- a/src/Tailviewer.Test/Ui/DataSourcesViewModelTest.cs
+++ b/src/Tailviewer.Test/Ui/DataSourcesViewModelTest.cs
@@ -765,5 +765,25 @@ namespace Tailviewer.Test.Ui
 			_model.CanBeDropped(file, folder, DataSourceDropType.Group, out var unused)
 			      .Should().BeFalse("because folder data sources do not partake in drag 'n drop operations");
 		}
+
+		[Test]
+		[Description("Verifies that grouped data sources are updated")]
+		[Issue("https://github.com/Kittyfisto/Tailviewer/issues/225")]
+		public void TestGroupFilesUpdate()
+		{
+			var file1 = _model.GetOrAddFile("A");
+			var file2 = _model.GetOrAddFile("B");
+			_model.OnDropped(file1, file2, DataSourceDropType.Group);
+
+			_model.Observable.Should().HaveCount(1, "because we've dropped two files into a group and thus there should only be one top-level data source");
+			var group = _model.Observable.First();
+
+			// The following lines verify that the model adds the new group to its internal (flat) list
+			// of all data sources. The view model uses said list for updating view models and there's
+			// no simple solution to verify an update call ATM.
+			_model.AllDataSourceViewModels.Should().Contain(file1);
+			_model.AllDataSourceViewModels.Should().Contain(file2);
+			_model.AllDataSourceViewModels.Should().Contain(group);
+		}
 	}
 }

--- a/src/Tailviewer/Ui/Controls/SidePanel/DataSources/DataSourcesViewModel.cs
+++ b/src/Tailviewer/Ui/Controls/SidePanel/DataSources/DataSourcesViewModel.cs
@@ -536,6 +536,7 @@ namespace Tailviewer.Ui.Controls.SidePanel.DataSources
 						merged.AddChild(source);
 						merged.AddChild(dest);
 						_observable.Insert(destIndex, merged);
+						_allDataSourceViewModels.Add(merged);
 						SelectedItem = merged;
 					}
 				}
@@ -546,5 +547,7 @@ namespace Tailviewer.Ui.Controls.SidePanel.DataSources
 		{
 			viewModel.AddChild(source);
 		}
+
+		internal IEnumerable<IDataSourceViewModel> AllDataSourceViewModels => _allDataSourceViewModels;
 	}
 }


### PR DESCRIPTION
The data sources view model would never call Update() on newly created groups. This caused values such as number of errors, warnings, etc.. to never be updated and remain at 0 instead.
The bug would only occur when the grouped data source was created during the session however, e.g. closing tailviewer and opening it again would then show the correct number of warnings 100% of the time.

Fixes #225
