### PR TITLE
Reposition mainwindow on start in case it doesn't fit the desktop area anymore #238

### DIFF
--- a/src/Tailviewer.Test/DesktopTest.cs
+++ b/src/Tailviewer.Test/DesktopTest.cs
@@ -1,0 +1,105 @@
+﻿using FluentAssertions;
+using Metrolib;
+using NUnit.Framework;
+using Tailviewer.Settings;
+using Size = System.Windows.Size;
+
+namespace Tailviewer.Test
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	[TestFixture]
+	public sealed class DesktopTest
+	{
+		[Test]
+		public void TestOneMonitorWindowFits()
+		{
+			var window = new WindowSettings {Left = 10, Top = 20, Width = 800, Height = 600};
+
+			var screen = new Desktop.Screen(new Desktop.Point(0, 0), new Size(1024, 768));
+			var desktop = new Desktop(new[] {screen});
+			var actualWindow = desktop.ClipToBoundaries(window);
+			actualWindow.Should().BeSameAs(window);
+			actualWindow.Left.Should().Be(10);
+			actualWindow.Top.Should().Be(20);
+			actualWindow.Width.Should().Be(800);
+			actualWindow.Height.Should().Be(600);
+		}
+
+		[Test]
+		public void TestOneMonitorWindowClipsLeft()
+		{
+			var window = new WindowSettings {Left = -1, Top = 20, Width = 800, Height = 600};
+
+			var screen = new Desktop.Screen(new Desktop.Point(0, 0), new Size(1024, 768));
+			var desktop = new Desktop(new[] {screen});
+			var actualWindow = desktop.ClipToBoundaries(window);
+			actualWindow.Should().NotBeSameAs(window);
+			actualWindow.Left.Should().Be(112, "because the window should've been moved to the center");
+			actualWindow.Top.Should().Be(84, "because the window should've been moved to the center");
+			actualWindow.Width.Should().Be(800);
+			actualWindow.Height.Should().Be(600);
+		}
+
+		[Test]
+		public void TestOneMonitorWindowClipsTop()
+		{
+			var window = new WindowSettings {Left = 10, Top = -1, Width = 800, Height = 600};
+
+			var screen = new Desktop.Screen(new Desktop.Point(0, 0), new Size(1024, 768));
+			var desktop = new Desktop(new[] {screen});
+			var actualWindow = desktop.ClipToBoundaries(window);
+			actualWindow.Should().NotBeSameAs(window);
+			actualWindow.Left.Should().Be(112, "because the window should've been moved to the center");
+			actualWindow.Top.Should().Be(84, "because the window should've been moved to the center");
+			actualWindow.Width.Should().Be(800);
+			actualWindow.Height.Should().Be(600);
+		}
+
+		[Test]
+		public void TestOneMonitorWindowClipsRight()
+		{
+			var window = new WindowSettings {Left = 225, Top = 20, Width = 800, Height = 600};
+
+			var screen = new Desktop.Screen(new Desktop.Point(0, 0), new Size(1024, 768));
+			var desktop = new Desktop(new[] {screen});
+			var actualWindow = desktop.ClipToBoundaries(window);
+			actualWindow.Should().NotBeSameAs(window);
+			actualWindow.Left.Should().Be(112, "because the window should've been moved to the center");
+			actualWindow.Top.Should().Be(84, "because the window should've been moved to the center");
+			actualWindow.Width.Should().Be(800);
+			actualWindow.Height.Should().Be(600);
+		}
+
+		[Test]
+		public void TestOneMonitorWindowClipsBottom()
+		{
+			var window = new WindowSettings {Left = 10, Top = 169, Width = 800, Height = 600};
+
+			var screen = new Desktop.Screen(new Desktop.Point(0, 0), new Size(1024, 768));
+			var desktop = new Desktop(new[] {screen});
+			var actualWindow = desktop.ClipToBoundaries(window);
+			actualWindow.Should().NotBeSameAs(window);
+			actualWindow.Left.Should().Be(112, "because the window should've been moved to the center");
+			actualWindow.Top.Should().Be(84, "because the window should've been moved to the center");
+			actualWindow.Width.Should().Be(800);
+			actualWindow.Height.Should().Be(600);
+		}
+
+		[Test]
+		public void TestOneMonitorWindowTooBig()
+		{
+			var window = new WindowSettings {Left = 10, Top = 169, Width = 1024, Height = 768};
+
+			var screen = new Desktop.Screen(new Desktop.Point(0, 0), new Size(800, 600));
+			var desktop = new Desktop(new[] {screen});
+			var actualWindow = desktop.ClipToBoundaries(window);
+			actualWindow.Should().NotBeSameAs(window);
+			actualWindow.Left.Should().Be(0, "because the window should've been moved to the center");
+			actualWindow.Top.Should().Be(0, "because the window should've been moved to the center");
+			actualWindow.Width.Should().Be(800);
+			actualWindow.Height.Should().Be(600);
+		}
+	}
+}

--- a/src/Tailviewer.Test/DesktopTest.cs
+++ b/src/Tailviewer.Test/DesktopTest.cs
@@ -15,7 +15,7 @@ namespace Tailviewer.Test
 		[Test]
 		public void TestOneMonitorWindowFits()
 		{
-			var window = new WindowSettings {Left = 10, Top = 20, Width = 800, Height = 600};
+			var window = new Desktop.Rectangle(new Desktop.Point(10, 20), new Size(800, 600));
 
 			var screen = new Desktop.Screen(new Desktop.Point(0, 0), new Size(1024, 768));
 			var desktop = new Desktop(new[] {screen});
@@ -30,7 +30,7 @@ namespace Tailviewer.Test
 		[Test]
 		public void TestOneMonitorWindowClipsLeft()
 		{
-			var window = new WindowSettings {Left = -1, Top = 20, Width = 800, Height = 600};
+			var window = new Desktop.Rectangle(new Desktop.Point(-1, 20), new Size(800, 600));
 
 			var screen = new Desktop.Screen(new Desktop.Point(0, 0), new Size(1024, 768));
 			var desktop = new Desktop(new[] {screen});
@@ -45,7 +45,7 @@ namespace Tailviewer.Test
 		[Test]
 		public void TestOneMonitorWindowClipsTop()
 		{
-			var window = new WindowSettings {Left = 10, Top = -1, Width = 800, Height = 600};
+			var window = new Desktop.Rectangle(new Desktop.Point(10, -1), new Size(800, 600));
 
 			var screen = new Desktop.Screen(new Desktop.Point(0, 0), new Size(1024, 768));
 			var desktop = new Desktop(new[] {screen});
@@ -60,7 +60,7 @@ namespace Tailviewer.Test
 		[Test]
 		public void TestOneMonitorWindowClipsRight()
 		{
-			var window = new WindowSettings {Left = 225, Top = 20, Width = 800, Height = 600};
+			var window = new Desktop.Rectangle(new Desktop.Point(225, 201), new Size(800, 600));
 
 			var screen = new Desktop.Screen(new Desktop.Point(0, 0), new Size(1024, 768));
 			var desktop = new Desktop(new[] {screen});
@@ -75,7 +75,7 @@ namespace Tailviewer.Test
 		[Test]
 		public void TestOneMonitorWindowClipsBottom()
 		{
-			var window = new WindowSettings {Left = 10, Top = 169, Width = 800, Height = 600};
+			var window = new Desktop.Rectangle(new Desktop.Point(10, 169), new Size(800, 600));
 
 			var screen = new Desktop.Screen(new Desktop.Point(0, 0), new Size(1024, 768));
 			var desktop = new Desktop(new[] {screen});
@@ -90,7 +90,7 @@ namespace Tailviewer.Test
 		[Test]
 		public void TestOneMonitorWindowTooBig()
 		{
-			var window = new WindowSettings {Left = 10, Top = 169, Width = 1024, Height = 768};
+			var window = new Desktop.Rectangle(new Desktop.Point(10, 169), new Size(1024, 768));
 
 			var screen = new Desktop.Screen(new Desktop.Point(0, 0), new Size(800, 600));
 			var desktop = new Desktop(new[] {screen});

--- a/src/Tailviewer.Test/DesktopTest.cs
+++ b/src/Tailviewer.Test/DesktopTest.cs
@@ -15,7 +15,7 @@ namespace Tailviewer.Test
 		[Test]
 		public void TestOneMonitorWindowFits()
 		{
-			var window = new Desktop.Rectangle(new Desktop.Point(10, 20), new Size(800, 600));
+			var window = new Desktop.Window(new Desktop.Point(10, 20), new Size(800, 600));
 
 			var screen = new Desktop.Screen(new Desktop.Point(0, 0), new Size(1024, 768));
 			var desktop = new Desktop(new[] {screen});
@@ -30,7 +30,7 @@ namespace Tailviewer.Test
 		[Test]
 		public void TestOneMonitorWindowClipsLeft()
 		{
-			var window = new Desktop.Rectangle(new Desktop.Point(-1, 20), new Size(800, 600));
+			var window = new Desktop.Window(new Desktop.Point(-1, 20), new Size(800, 600));
 
 			var screen = new Desktop.Screen(new Desktop.Point(0, 0), new Size(1024, 768));
 			var desktop = new Desktop(new[] {screen});
@@ -45,7 +45,7 @@ namespace Tailviewer.Test
 		[Test]
 		public void TestOneMonitorWindowClipsTop()
 		{
-			var window = new Desktop.Rectangle(new Desktop.Point(10, -1), new Size(800, 600));
+			var window = new Desktop.Window(new Desktop.Point(10, -1), new Size(800, 600));
 
 			var screen = new Desktop.Screen(new Desktop.Point(0, 0), new Size(1024, 768));
 			var desktop = new Desktop(new[] {screen});
@@ -60,7 +60,7 @@ namespace Tailviewer.Test
 		[Test]
 		public void TestOneMonitorWindowClipsRight()
 		{
-			var window = new Desktop.Rectangle(new Desktop.Point(225, 201), new Size(800, 600));
+			var window = new Desktop.Window(new Desktop.Point(225, 201), new Size(800, 600));
 
 			var screen = new Desktop.Screen(new Desktop.Point(0, 0), new Size(1024, 768));
 			var desktop = new Desktop(new[] {screen});
@@ -75,7 +75,7 @@ namespace Tailviewer.Test
 		[Test]
 		public void TestOneMonitorWindowClipsBottom()
 		{
-			var window = new Desktop.Rectangle(new Desktop.Point(10, 169), new Size(800, 600));
+			var window = new Desktop.Window(new Desktop.Point(10, 169), new Size(800, 600));
 
 			var screen = new Desktop.Screen(new Desktop.Point(0, 0), new Size(1024, 768));
 			var desktop = new Desktop(new[] {screen});
@@ -90,7 +90,7 @@ namespace Tailviewer.Test
 		[Test]
 		public void TestOneMonitorWindowTooBig()
 		{
-			var window = new Desktop.Rectangle(new Desktop.Point(10, 169), new Size(1024, 768));
+			var window = new Desktop.Window(new Desktop.Point(10, 169), new Size(1024, 768));
 
 			var screen = new Desktop.Screen(new Desktop.Point(0, 0), new Size(800, 600));
 			var desktop = new Desktop(new[] {screen});

--- a/src/Tailviewer.Test/RectangleTest.cs
+++ b/src/Tailviewer.Test/RectangleTest.cs
@@ -1,0 +1,75 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Tailviewer.Settings;
+
+namespace Tailviewer.Test
+{
+	[TestFixture]
+	public sealed class RectangleTest
+	{
+		[Test]
+		public void TestCutCompletelyInside()
+		{
+			var screen = new Desktop.Rectangle(0, 0, 10, 10);
+			var window = new Desktop.Rectangle(4, 4, 2, 2);
+			var cut = window.Cut(screen);
+			cut.Should().BeEmpty("because the window is completely within the screen");
+		}
+
+		[Test]
+		public void TestCutCompletelyOutside()
+		{
+			var screen = new Desktop.Rectangle(0, 0, 10, 10);
+			var window = new Desktop.Rectangle(11, 11, 2, 2);
+			var cut = window.Cut(screen);
+			cut.Should().Equal(new[]{window},
+			                      "because the screen doesn't cut anway anything from the window because the latter is complete off-screen");
+		}
+
+		[Test]
+		public void TestCutIntersectLeft()
+		{
+			var screen = new Desktop.Rectangle(0, 0, 10, 10);
+			var window = new Desktop.Rectangle(-1, 4, 2, 2);
+			var cut = window.Cut(screen);
+			cut.Should().Equal(new[]{new Desktop.Rectangle(-1, 4, 1, 2)},
+			                      "because the screen cuts away the right-hand side of the window");
+		}
+
+		[Test]
+		public void TestCutIntersectRight()
+		{
+			var screen = new Desktop.Rectangle(10, 10, 10, 10);
+			var window = new Desktop.Rectangle(5, 11, 10, 4);
+			var cut = window.Cut(screen);
+			cut.Should().Equal(new[]{new Desktop.Rectangle(5, 11, 5, 4)},
+			                   "because the screen cuts away the right-hand side of the window");
+		}
+
+		[Test]
+		public void TestCutWindowBiggerThanScreen()
+		{
+			var screen = new Desktop.Rectangle(0, 0, 20, 10);
+			var window = new Desktop.Rectangle(-10, -10, 60, 30);
+			var cut = window.Cut(screen);
+			cut.Should().BeEquivalentTo(new[]
+			                            {
+											// Top "row"
+											new Desktop.Rectangle(-10, -10, 10, 10),
+											new Desktop.Rectangle(0, -10, 20, 10),
+											new Desktop.Rectangle(20, -10, 30, 10),
+
+											// "Left side"
+											new Desktop.Rectangle(-10, 0, 10, 10),
+											// "Right side"
+											new Desktop.Rectangle(20, 0, 30, 10),
+
+											// "Bottom row"
+											new Desktop.Rectangle(-10, 10, 10, 10),
+											new Desktop.Rectangle(0, 10, 20, 10),
+											new Desktop.Rectangle(20, 10, 30, 10)
+			                            },
+			                   "because the screen cuts a straight rectangle into the window, which should have been modelled as six rectangles");
+		}
+	}
+}

--- a/src/Tailviewer.Test/Tailviewer.Test.csproj
+++ b/src/Tailviewer.Test/Tailviewer.Test.csproj
@@ -187,6 +187,7 @@
     <Compile Include="LocalTest.cs" />
     <Compile Include="QuickFilterIdTest.cs" />
     <Compile Include="ReaderWriterTest.cs" />
+    <Compile Include="RectangleTest.cs" />
     <Compile Include="ServiceContainerTest.cs" />
     <Compile Include="SerializableTypeExtensions.cs" />
     <Compile Include="Settings\ApplicationSettingsTest.cs" />

--- a/src/Tailviewer.Test/Tailviewer.Test.csproj
+++ b/src/Tailviewer.Test/Tailviewer.Test.csproj
@@ -179,6 +179,7 @@
     <Compile Include="ChangelogTest.cs" />
     <Compile Include="DataSourceIdTest.cs" />
     <Compile Include="BusinessLogic\Highlighters\HighlighterIdTest.cs" />
+    <Compile Include="DesktopTest.cs" />
     <Compile Include="FlakyTestAttribute.cs" />
     <Compile Include="IssueAttribute.cs" />
     <Compile Include="EnhancementAttribute.cs" />

--- a/src/Tailviewer/App.cs
+++ b/src/Tailviewer/App.cs
@@ -24,6 +24,7 @@ using Tailviewer.BusinessLogic.LogFiles;
 using Tailviewer.BusinessLogic.Plugins;
 using Tailviewer.Core;
 using Tailviewer.Core.Settings;
+using Tailviewer.Settings;
 using Tailviewer.Settings.Bookmarks;
 using Tailviewer.Ui;
 using ApplicationSettings = Tailviewer.Settings.ApplicationSettings;
@@ -232,7 +233,8 @@ namespace Tailviewer
 						{
 							DataContext = windowViewModel
 						};
-
+						
+						settings.MainWindow.ClipToBounds(Desktop.Current);
 						settings.MainWindow.RestoreTo(window);
 
 						stopwatch.Stop();

--- a/src/Tailviewer/Settings/Desktop.cs
+++ b/src/Tailviewer/Settings/Desktop.cs
@@ -41,38 +41,39 @@ namespace Tailviewer.Settings
 		///     screen and only starts to reduce the width / height of the window if either monitor
 		///     has a lower resolution than the current width / height requires.
 		/// </remarks>
-		/// <param name="settings"></param>
+		/// <param name="window"></param>
 		/// <returns>
 		///     A new object with corrected position and / or area or the existing object in case no modification was
 		///     necessary.
 		/// </returns>
 		[Pure]
-		public WindowSettings ClipToBoundaries(WindowSettings settings)
+		public Rectangle ClipToBoundaries(Rectangle window)
 		{
 			// If we didn't detect any monitors then somethings going on, but whatever it may be, we cannot move on...
 			if (_screens.Count == 0)
 			{
 				Log.WarnFormat("Unable to fit window into current desktop area: Not a single monitor was detected!");
-				return settings;
+				return window;
 			}
 
-			// We'll first check if the window fits into one existing screen already.
-			// If it does, then we don't need to do anything.
-			foreach (var screen in _screens)
-				if (screen.Contains(settings))
-					return settings;
+			// We'll first check if the window fits into the current virtual desktop area.
+			// If it consists of more than one screen, then we'll try to figure out if there's a portion
+			// of the window that's hidden, and if there is, only then will we try to move / resize the
+			// window to become visible again.
+			if (Contains(window))
+				return window;
 
 			Log.InfoFormat("The window doesn't fit into the current desktop area anymore, trying to find a more suitable location...");
 
 			// We'll try to place the window on the closest screen to its current position.
 			// This is incredibly useful if the window is only partially hidden.
-			var screensSortedByDistance = SortScreensByDistanceToWindow(settings, _screens);
+			var screensSortedByDistance = SortScreensByDistanceToWindow(window, _screens);
 			foreach (var screen in screensSortedByDistance)
 			{
-				if (screen.TryMoveWindowIntoScreen(settings, out var newSettings))
+				if (screen.TryMoveWindowIntoScreen(window, out var newWindow))
 				{
-					Log.InfoFormat("Found new window location: {0}", newSettings);
-					return newSettings;
+					Log.InfoFormat("Found new window location: {0}", newWindow);
+					return newWindow;
 				}
 			}
 
@@ -83,14 +84,30 @@ namespace Tailviewer.Settings
 			// We'll ditch our closest screen approach and instead try to move the window to the screen with
 			// the greatest screen area.
 			var screensSortedByArea = SortScreensByArea(_screens);
-			var modifiedSettings = screensSortedByArea[0].FitWindowInto(settings);
+			var modifiedSettings = screensSortedByArea[0].FitWindowInto(window);
 			Log.InfoFormat("Found new window location and size: {0}", modifiedSettings);
 			return modifiedSettings;
 		}
 
 		[Pure]
+		public bool Contains(Rectangle window)
+		{
+			// We'll cut away from the given window until all screens have performed a cut.
+			IReadOnlyList<Rectangle> windowPortions = new List<Rectangle> {window};
+			foreach (var screen in _screens)
+			{
+				windowPortions = screen.CutAway(windowPortions);
+			}
+
+			// If the screens cut away every single portion of the window then we can conclude
+			// that everything is showing up as expected (even if the window is placed
+			// among multiple screen boundaries).
+			return windowPortions.Count == 0;
+		}
+
+		[Pure]
 		private static IReadOnlyCollection<Screen> SortScreensByDistanceToWindow(
-			WindowSettings window,
+			Rectangle window,
 			IReadOnlyCollection<Screen> screens)
 		{
 			var centerPoint = new Point(window.Left + window.Width / 2, window.Top + window.Height / 2);
@@ -140,24 +157,80 @@ namespace Tailviewer.Settings
 			#endregion
 		}
 
-		/// <summary>
-		///     Represents one screen connected to the current system.
-		/// </summary>
-		public sealed class Screen
+		public class Rectangle
 		{
+			#region Equality members
+
+			protected bool Equals(Rectangle other)
+			{
+				return _size.Equals(other._size) && _topLeft.Equals(other._topLeft);
+			}
+
+			public override bool Equals(object obj)
+			{
+				if (ReferenceEquals(null, obj)) return false;
+				if (ReferenceEquals(this, obj)) return true;
+				if (obj.GetType() != this.GetType()) return false;
+				return Equals((Rectangle) obj);
+			}
+
+			public override int GetHashCode()
+			{
+				unchecked
+				{
+					return (_size.GetHashCode() * 397) ^ _topLeft.GetHashCode();
+				}
+			}
+
+			public static bool operator ==(Rectangle left, Rectangle right)
+			{
+				return Equals(left, right);
+			}
+
+			public static bool operator !=(Rectangle left, Rectangle right)
+			{
+				return !Equals(left, right);
+			}
+
+			#endregion
+
 			private readonly Size _size;
 			private readonly Point _topLeft;
 
-			public Screen(Point topLeft, Size size)
+			public Rectangle()
+			{}
+			public Rectangle(double left, double top, double width, double height)
+				: this(new Point(left, top), new Size(width, height))
+			{}
+
+			public Rectangle(Point topLeft, Size size)
 			{
 				_topLeft = topLeft;
 				_size = size;
 			}
 
-			public Screen(System.Windows.Forms.Screen screen)
-				: this(new Point(screen.Bounds.X, screen.Bounds.Y),
-				       new Size(screen.Bounds.Width, screen.Bounds.Height))
+			public Rectangle(WindowSettings settings)
+				: this(new Point(settings.Left, settings.Top), new Size(settings.Width, settings.Height))
+			{ }
+
+			public double Top
 			{
+				get { return _topLeft.Y; }
+			}
+
+			public double Left
+			{
+				get { return _topLeft.X; }
+			}
+
+			public double Bottom
+			{
+				get { return _topLeft.Y + _size.Height; }
+			}
+
+			public double Right
+			{
+				get { return _topLeft.X + _size.Width; }
 			}
 
 			public Point TopLeft
@@ -167,17 +240,17 @@ namespace Tailviewer.Settings
 
 			public Point TopRight
 			{
-				get { return new Point(_topLeft.X + _size.Width, _topLeft.Y); }
+				get { return new Point(Right, Top); }
 			}
 
 			public Point BottomRight
 			{
-				get { return new Point(_topLeft.X + _size.Width, _topLeft.Y + _size.Height); }
+				get { return new Point(Right, Bottom); }
 			}
 
 			public Point BottomLeft
 			{
-				get { return new Point(_topLeft.X, _topLeft.Y + _size.Height); }
+				get { return new Point(Left, Bottom); }
 			}
 
 			public Point Center
@@ -190,6 +263,30 @@ namespace Tailviewer.Settings
 				get { return _size.Width * _size.Height; }
 			}
 
+			public double Width
+			{
+				get { return _size.Width; }
+			}
+
+			public double Height
+			{
+				get { return _size.Height; }
+			}
+
+			public Size Size
+			{
+				get { return _size; }
+			}
+
+			#region Overrides of Object
+
+			public override string ToString()
+			{
+				return $"(({TopLeft}) ({Size}))";
+			}
+
+			#endregion
+
 			/// <summary>
 			///     Tests if this screen fully contains the given window.
 			///     If the window is only partially contained (e.g. is bigger than this screen) or if
@@ -198,50 +295,179 @@ namespace Tailviewer.Settings
 			/// <param name="settings"></param>
 			/// <returns></returns>
 			[Pure]
-			public bool Contains(WindowSettings settings)
+			public bool Contains(Rectangle settings)
 			{
-				return !(settings.Left < _topLeft.X ||
-				         settings.Top < _topLeft.Y ||
-				         settings.Left + settings.Width > TopRight.X ||
-				         settings.Top + settings.Height > BottomRight.Y);
+				return !(settings.Left < Left ||
+				         settings.Top < Top ||
+				         settings.Right > Right ||
+				         settings.Bottom > Bottom);
+			}
+
+			/// <summary>
+			/// Returns the shape (split up into zero or more rectangles) that results if one were
+			/// to cut away the portion of this rectangle, which intersects with the given one.
+			/// </summary>
+			/// <param name="other"></param>
+			/// <returns></returns>
+			[Pure]
+			public IReadOnlyList<Rectangle> Cut(Rectangle other)
+			{
+				// If the other rectangle fully contains this one then nothing
+				// remains after the cut...
+				if (other.Contains(this))
+					return new Rectangle[0];
+
+				// If on the other hand, the two rectangles don't overlap even one bit,
+				// then nothing changes due to the cut and we can simply return this rectangle
+				if (!other.Overlap(this))
+					return new Rectangle[]{this};
+
+				/*
+				// So we know that there's a partial overlap. We'll just have to figure
+				// out what the resulting shape looks like.
+				// There's several possibilities:
+				// 1. The cut removes an inside portion of this rectangle
+				if (Contains(other))
+					throw new NotImplementedException("Cutting holes not implemented");
+				*/
+
+				IEnumerable<Rectangle> CutOnce(IEnumerable<Rectangle> rectangles)
+				{
+					var pass1 = rectangles.SelectMany(rectangle => rectangle.CutHorizontal(other.Top)).ToList();
+					var pass2 = pass1.SelectMany(rectangle => rectangle.CutHorizontal(other.Bottom)).ToList();
+					var pass3 = pass2.SelectMany(rectangle => rectangle.CutVertical(other.Left)).ToList();
+					var pass4 = pass3.SelectMany(rectangle => rectangle.CutVertical(other.Right)).ToList();
+					return pass4;
+				}
+
+				// We want to find out the area of this rectangle, which is left when the overlapping area with the other
+				// rectangle is cut away. This can be achieved in the following way:
+				// We first cut this rectangle into pieces along the four (infinite) lines of the other rectangle.
+				// Then we do a second pass where we cut the resulting rectangles once more by the same lines again.
+				// Now we should have a list of up to 9 rectangles which are either **completely** outside or
+				// completely inside the screen, i.e. there's no intersections anymore.
+				// All that is left to do now is to remove those rectangles which are part of the screen and we're
+				// left with those hat are outside of the screen.
+				// This algorithm accounts for all types of intersections:
+				// - Intersection along one edge of the screen resulting in half of the window to be cut
+				// - Intersection along two edges of the screen, resulting in a "corner" to be cut, yielding an L-shape
+				// - Full intersection in which the screen cuts away a hole inside the window.
+				//var pass1 = CutOnce(new[] {this});
+				//var pass2 = CutOnce(pass1);
+				var tmpResult = CutOnce(new[] {this});
+				// The result is almost there, after we've cut up this rectangle, we want to remove
+				// those portions that are completely inside the screen, leaving only those parts which do not.
+				var finalResult = tmpResult.Where(x => !other.Contains(x)).ToList();
+				return finalResult;
+			}
+
+			[Pure]
+			private IEnumerable<Rectangle> CutHorizontal(double y)
+			{
+				if (y <= Top || y >= Bottom)
+					return new[] {this};
+
+				return new[]
+				{
+					new Rectangle(Left, Top, Width, y - Top),
+					new Rectangle(Left, y, Width, Bottom - y),
+				};
+			}
+
+			[Pure]
+			private IEnumerable<Rectangle> CutVertical(double x)
+			{
+				if (x <= Left || x >= Right)
+					return new[] {this};
+
+				return new[]
+				{
+					new Rectangle(Left, Top, x - Left, Height),
+					new Rectangle(x, Top, Right - x, Height)
+				};
+			}
+
+			[Pure]
+			public bool Overlap(Rectangle rectangle)
+			{
+				if (rectangle.Contains(TopLeft) || rectangle.Contains(TopRight) ||
+				    rectangle.Contains(BottomLeft) || rectangle.Contains(BottomRight))
+					return true;
+
+				if (Contains(rectangle.TopLeft) || Contains(rectangle.TopRight) ||
+				    Contains(rectangle.BottomLeft) || rectangle.Contains(BottomRight))
+					return true;
+
+				return false;
+			}
+
+			[Pure]
+			public bool Contains(Point topLeft)
+			{
+				return !(topLeft.X < Left || topLeft.Y > Right ||
+				       topLeft.Y < Top || topLeft.Y > Bottom);
+			}
+		}
+
+		/// <summary>
+		///     Represents one screen connected to the current system.
+		/// </summary>
+		public sealed class Screen
+			: Rectangle
+		{
+
+			public Screen(Point topLeft, Size size)
+				: base(topLeft, size)
+			{ }
+
+			public Screen(System.Windows.Forms.Screen screen)
+				: base(new Point(screen.Bounds.X, screen.Bounds.Y),
+				       new Size(screen.Bounds.Width, screen.Bounds.Height))
+			{
 			}
 
 			/// <summary>
 			///    Tries to bring the given window into view.
 			/// </summary>
-			/// <param name="settings"></param>
-			/// <param name="movedSettings"></param>
+			/// <param name="window"></param>
+			/// <param name="movedWindow"></param>
 			/// <returns></returns>
-			public bool TryMoveWindowIntoScreen(WindowSettings settings, out WindowSettings movedSettings)
+			public bool TryMoveWindowIntoScreen(Rectangle window, out Rectangle movedWindow)
 			{
-				movedSettings = null;
+				movedWindow = null;
 
-				if (settings.Width > _size.Width)
+				if (window.Width > Size.Width)
 					return false;
-				if (settings.Height > _size.Height)
+				if (window.Height > Size.Height)
 					return false;
 
 				// The window will fit, we'll just have to move it into view.
 				// Let's place it so its centered on the screen...
-				var halfWidth = settings.Width / 2;
-				var halfHeight = settings.Height / 2;
+				var halfWidth = window.Width / 2;
+				var halfHeight = window.Height / 2;
 				var center = Center;
 				var topLeft = new Point(center.X - halfWidth, center.Y - halfHeight);
-				movedSettings = settings.Clone();
-				movedSettings.Left = topLeft.X;
-				movedSettings.Top = topLeft.Y;
+				movedWindow = new Rectangle(topLeft, window.Size);
 				return true;
 			}
 
 			[Pure]
-			public WindowSettings FitWindowInto(WindowSettings settings)
+			public Rectangle FitWindowInto(Rectangle settings)
 			{
-				var newSettings = settings.Clone();
-				newSettings.Left = _topLeft.X;
-				newSettings.Top = _topLeft.Y;
-				newSettings.Width = _size.Width;
-				newSettings.Height = _size.Height;
+				var newSettings = new Rectangle(TopLeft, Size);
 				return newSettings;
+			}
+
+			[Pure]
+			public IReadOnlyList<Rectangle> CutAway(IReadOnlyList<Rectangle> windowPortions)
+			{
+				var result = new List<Rectangle>();
+				foreach (var window in windowPortions)
+				{
+					result.AddRange(window.Cut(this));
+				}
+
+				return result;
 			}
 		}
 	}

--- a/src/Tailviewer/Settings/Desktop.cs
+++ b/src/Tailviewer/Settings/Desktop.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Reflection;
+using log4net;
+using Metrolib;
+using Size = System.Windows.Size;
+
+namespace Tailviewer.Settings
+{
+	/// <summary>
+	/// </summary>
+	/// <remarks>
+	///     TODO: This might be of interest for others and could be moved to Metrolib.
+	/// </remarks>
+	public sealed class Desktop
+	{
+		private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+		private readonly IReadOnlyCollection<Screen> _screens;
+
+		public static Desktop Current
+		{
+			get
+			{
+				return new Desktop(System.Windows.Forms.Screen.AllScreens.Select(x => new Screen(x)).ToList());
+			}
+		}
+
+		public Desktop(IReadOnlyCollection<Screen> screens)
+		{
+			_screens = screens;
+		}
+
+		/// <summary>
+		///     Clips the given settings so the window fits into the current desktop.
+		/// </summary>
+		/// <remarks>
+		///     The current implementation tries to **first** move the window to an available
+		///     screen and only starts to reduce the width / height of the window if either monitor
+		///     has a lower resolution than the current width / height requires.
+		/// </remarks>
+		/// <param name="settings"></param>
+		/// <returns>
+		///     A new object with corrected position and / or area or the existing object in case no modification was
+		///     necessary.
+		/// </returns>
+		[Pure]
+		public WindowSettings ClipToBoundaries(WindowSettings settings)
+		{
+			// If we didn't detect any monitors then somethings going on, but whatever it may be, we cannot move on...
+			if (_screens.Count == 0)
+			{
+				Log.WarnFormat("Unable to fit window into current desktop area: Not a single monitor was detected!");
+				return settings;
+			}
+
+			// We'll first check if the window fits into one existing screen already.
+			// If it does, then we don't need to do anything.
+			foreach (var screen in _screens)
+				if (screen.Contains(settings))
+					return settings;
+
+			Log.InfoFormat("The window doesn't fit into the current desktop area anymore, trying to find a more suitable location...");
+
+			// We'll try to place the window on the closest screen to its current position.
+			// This is incredibly useful if the window is only partially hidden.
+			var screensSortedByDistance = SortScreensByDistanceToWindow(settings, _screens);
+			foreach (var screen in screensSortedByDistance)
+			{
+				if (screen.TryMoveWindowIntoScreen(settings, out var newSettings))
+				{
+					Log.InfoFormat("Found new window location: {0}", newSettings);
+					return newSettings;
+				}
+			}
+
+			Log.InfoFormat("The window's size doesn't fit into any of the available monitor(s): Resizing the window so it will fit");
+
+			// Moving the window alone doesn't cut it, we'll have to reduce the windows size to accomodate
+			// the apparent change in screens.
+			// We'll ditch our closest screen approach and instead try to move the window to the screen with
+			// the greatest screen area.
+			var screensSortedByArea = SortScreensByArea(_screens);
+			var modifiedSettings = screensSortedByArea[0].FitWindowInto(settings);
+			Log.InfoFormat("Found new window location and size: {0}", modifiedSettings);
+			return modifiedSettings;
+		}
+
+		[Pure]
+		private static IReadOnlyCollection<Screen> SortScreensByDistanceToWindow(
+			WindowSettings window,
+			IReadOnlyCollection<Screen> screens)
+		{
+			var centerPoint = new Point(window.Left + window.Width / 2, window.Top + window.Height / 2);
+			var sorted = screens.OrderBy(x => x.Center.SquaredDistanceTo(centerPoint)).ToList();
+			return sorted;
+		}
+
+		[Pure]
+		private static IReadOnlyList<Screen> SortScreensByArea(IReadOnlyCollection<Screen> screens)
+		{
+			var sorted = screens.OrderBy(x => x.Area).ToList();
+			return sorted;
+		}
+
+		public struct Point
+		{
+			public readonly double X;
+			public readonly double Y;
+
+			public Point(double x, double y)
+			{
+				X = x;
+				Y = y;
+			}
+
+			[Pure]
+			public double DistanceTo(Point other)
+			{
+				return Math.Sqrt(SquaredDistanceTo(other));
+			}
+
+			[Pure]
+			public double SquaredDistanceTo(Point other)
+			{
+				var dX = X - other.X;
+				var dY = Y - other.Y;
+				return dX * dX + dY * dY;
+			}
+
+			#region Overrides of ValueType
+
+			public override string ToString()
+			{
+				return $"{X}, {Y}";
+			}
+
+			#endregion
+		}
+
+		/// <summary>
+		///     Represents one screen connected to the current system.
+		/// </summary>
+		public sealed class Screen
+		{
+			private readonly Size _size;
+			private readonly Point _topLeft;
+
+			public Screen(Point topLeft, Size size)
+			{
+				_topLeft = topLeft;
+				_size = size;
+			}
+
+			public Screen(System.Windows.Forms.Screen screen)
+				: this(new Point(screen.Bounds.X, screen.Bounds.Y),
+				       new Size(screen.Bounds.Width, screen.Bounds.Height))
+			{
+			}
+
+			public Point TopLeft
+			{
+				get { return _topLeft; }
+			}
+
+			public Point TopRight
+			{
+				get { return new Point(_topLeft.X + _size.Width, _topLeft.Y); }
+			}
+
+			public Point BottomRight
+			{
+				get { return new Point(_topLeft.X + _size.Width, _topLeft.Y + _size.Height); }
+			}
+
+			public Point BottomLeft
+			{
+				get { return new Point(_topLeft.X, _topLeft.Y + _size.Height); }
+			}
+
+			public Point Center
+			{
+				get { return new Point(_topLeft.X + _size.Width / 2, _topLeft.Y + _size.Height / 2); }
+			}
+
+			public double Area
+			{
+				get { return _size.Width * _size.Height; }
+			}
+
+			/// <summary>
+			///     Tests if this screen fully contains the given window.
+			///     If the window is only partially contained (e.g. is bigger than this screen) or if
+			///     the window is completely outside this screen, then false is returned.
+			/// </summary>
+			/// <param name="settings"></param>
+			/// <returns></returns>
+			[Pure]
+			public bool Contains(WindowSettings settings)
+			{
+				return !(settings.Left < _topLeft.X ||
+				         settings.Top < _topLeft.Y ||
+				         settings.Left + settings.Width > TopRight.X ||
+				         settings.Top + settings.Height > BottomRight.Y);
+			}
+
+			/// <summary>
+			///    Tries to bring the given window into view.
+			/// </summary>
+			/// <param name="settings"></param>
+			/// <param name="movedSettings"></param>
+			/// <returns></returns>
+			public bool TryMoveWindowIntoScreen(WindowSettings settings, out WindowSettings movedSettings)
+			{
+				movedSettings = null;
+
+				if (settings.Width > _size.Width)
+					return false;
+				if (settings.Height > _size.Height)
+					return false;
+
+				// The window will fit, we'll just have to move it into view.
+				// Let's place it so its centered on the screen...
+				var halfWidth = settings.Width / 2;
+				var halfHeight = settings.Height / 2;
+				var center = Center;
+				var topLeft = new Point(center.X - halfWidth, center.Y - halfHeight);
+				movedSettings = settings.Clone();
+				movedSettings.Left = topLeft.X;
+				movedSettings.Top = topLeft.Y;
+				return true;
+			}
+
+			[Pure]
+			public WindowSettings FitWindowInto(WindowSettings settings)
+			{
+				var newSettings = settings.Clone();
+				newSettings.Left = _topLeft.X;
+				newSettings.Top = _topLeft.Y;
+				newSettings.Width = _size.Width;
+				newSettings.Height = _size.Height;
+				return newSettings;
+			}
+		}
+	}
+}

--- a/src/Tailviewer/Settings/IMainWindowSettings.cs
+++ b/src/Tailviewer/Settings/IMainWindowSettings.cs
@@ -48,6 +48,7 @@ namespace Tailviewer.Settings
 		void Save(XmlWriter writer);
 		void Restore(XmlReader reader);
 		void UpdateFrom(Window window);
+		void ClipToBounds(Desktop desktop);
 		void RestoreTo(Window window);
 	}
 }

--- a/src/Tailviewer/Settings/MainWindowSettings.cs
+++ b/src/Tailviewer/Settings/MainWindowSettings.cs
@@ -112,18 +112,23 @@ namespace Tailviewer.Settings
 			_window.UpdateFrom(window);
 		}
 
-		public void RestoreTo(Window window)
+		public void ClipToBounds(Desktop desktop)
 		{
-			var currentRectangle = new Desktop.Rectangle(_window);
-			var newRectangle = Desktop.Current.ClipToBoundaries(currentRectangle);
+			var currentRectangle = new Desktop.Window(_window);
+			var newRectangle = desktop.ClipToBoundaries(currentRectangle);
 			if (newRectangle != currentRectangle)
 			{
 				_window.Left = newRectangle.Left;
 				_window.Top = newRectangle.Top;
 				_window.Width = newRectangle.Width;
 				_window.Height = newRectangle.Height;
+				if (newRectangle.IsMaximized)
+					_window.State = WindowState.Maximized;
 			}
+		}
 
+		public void RestoreTo(Window window)
+		{
 			_window.RestoreTo(window);
 			window.Topmost = AlwaysOnTop;
 		}

--- a/src/Tailviewer/Settings/MainWindowSettings.cs
+++ b/src/Tailviewer/Settings/MainWindowSettings.cs
@@ -63,7 +63,7 @@ namespace Tailviewer.Settings
 			IsLeftSidePanelVisible = other.IsLeftSidePanelVisible;
 		}
 
-		private readonly WindowSettings _window;
+		private WindowSettings _window;
 
 		object ICloneable.Clone()
 		{
@@ -114,6 +114,7 @@ namespace Tailviewer.Settings
 
 		public void RestoreTo(Window window)
 		{
+			_window = Desktop.Current.ClipToBoundaries(_window);
 			_window.RestoreTo(window);
 			window.Topmost = AlwaysOnTop;
 		}

--- a/src/Tailviewer/Settings/MainWindowSettings.cs
+++ b/src/Tailviewer/Settings/MainWindowSettings.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Diagnostics.Contracts;
+using System.Reflection;
 using System.Windows;
 using System.Xml;
+using log4net;
 using Metrolib;
 
 namespace Tailviewer.Settings
@@ -10,6 +12,8 @@ namespace Tailviewer.Settings
 		: IMainWindowSettings
 		, ICloneable
 	{
+		private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
 		public double Height
 		{
 			get { return _window.Height; }
@@ -114,16 +118,23 @@ namespace Tailviewer.Settings
 
 		public void ClipToBounds(Desktop desktop)
 		{
-			var currentRectangle = new Desktop.Window(_window);
-			var newRectangle = desktop.ClipToBoundaries(currentRectangle);
-			if (newRectangle != currentRectangle)
+			try
 			{
-				_window.Left = newRectangle.Left;
-				_window.Top = newRectangle.Top;
-				_window.Width = newRectangle.Width;
-				_window.Height = newRectangle.Height;
-				if (newRectangle.IsMaximized)
-					_window.State = WindowState.Maximized;
+				var currentRectangle = new Desktop.Window(_window);
+				var newRectangle = desktop.ClipToBoundaries(currentRectangle);
+				if (newRectangle != currentRectangle)
+				{
+					_window.Left = newRectangle.Left;
+					_window.Top = newRectangle.Top;
+					_window.Width = newRectangle.Width;
+					_window.Height = newRectangle.Height;
+					if (newRectangle.IsMaximized)
+						_window.State = WindowState.Maximized;
+				}
+			}
+			catch (Exception e)
+			{
+				Log.ErrorFormat("Caught unexpected exception while trying to clip window to desktop bounds: {0}", e);
 			}
 		}
 

--- a/src/Tailviewer/Settings/MainWindowSettings.cs
+++ b/src/Tailviewer/Settings/MainWindowSettings.cs
@@ -114,7 +114,16 @@ namespace Tailviewer.Settings
 
 		public void RestoreTo(Window window)
 		{
-			_window = Desktop.Current.ClipToBoundaries(_window);
+			var currentRectangle = new Desktop.Rectangle(_window);
+			var newRectangle = Desktop.Current.ClipToBoundaries(currentRectangle);
+			if (newRectangle != currentRectangle)
+			{
+				_window.Left = newRectangle.Left;
+				_window.Top = newRectangle.Top;
+				_window.Width = newRectangle.Width;
+				_window.Height = newRectangle.Height;
+			}
+
 			_window.RestoreTo(window);
 			window.Topmost = AlwaysOnTop;
 		}

--- a/src/Tailviewer/Tailviewer.csproj
+++ b/src/Tailviewer/Tailviewer.csproj
@@ -85,6 +85,7 @@
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xaml">
@@ -131,6 +132,7 @@
     <Compile Include="Settings\Bookmarks\IBookmarks.cs" />
     <Compile Include="Settings\CustomFormats\CustomFormatSettings.cs" />
     <Compile Include="Settings\CustomFormats\CustomLogFileFormat.cs" />
+    <Compile Include="Settings\Desktop.cs" />
     <Compile Include="Settings\ICustomFormatsSettings.cs" />
     <Compile Include="Settings\ILogViewerSettings.cs" />
     <Compile Include="Settings\LogFileSettings.cs" />


### PR DESCRIPTION
- [x] Modify main window position and/or size in case it doesn't fit the virtual desktop area anymore during startup (for example because the monitors have been changed, resolution was changed, etc...)
- [x] The main window is moved in case the window clips a particular monitor and is moved to the closest monitor
- [x] The main window is resized to a smaller size in case there's no screen anymore which can hold the full window
- [x] The main window isn't moved in case it has been placed across multiple screens (this is currently broken and should be fixed before the merge)
- [x] Exceptions are caught so that TV doesn't crash on startup in case something unexpected happens (such as Winforms throwing upon enumerating screens)
- [x] TV's actions are logged so the reason why the screen is moved is part of the log file

Fixes #238