### PR TITLE
Tailviewer should never start minimized #250

### DIFF
--- a/src/Tailviewer.Test/Settings/MainWindowSettingsTest.cs
+++ b/src/Tailviewer.Test/Settings/MainWindowSettingsTest.cs
@@ -37,6 +37,46 @@ namespace Tailviewer.Test.Settings
 		}
 
 		[Test]
+		[RequiresThread(ApartmentState.STA)]
+		[Issue("https://github.com/Kittyfisto/Tailviewer/issues/250")]
+		public void TestRestoreToMinimized1()
+		{
+			var settings = new MainWindowSettings
+			{
+				Width = 9001,
+				Height = 42,
+				State = WindowState.Normal
+			};
+			settings.State = WindowState.Minimized;
+
+			var window = new Window();
+			settings.RestoreTo(window);
+			window.Width.Should().Be(9001);
+			window.Height.Should().Be(42);
+			window.WindowState.Should().Be(WindowState.Normal);
+		}
+
+		[Test]
+		[RequiresThread(ApartmentState.STA)]
+		[Issue("https://github.com/Kittyfisto/Tailviewer/issues/250")]
+		public void TestRestoreToMinimized2()
+		{
+			var settings = new MainWindowSettings
+			{
+				Width = 9001,
+				Height = 42,
+				State = WindowState.Maximized
+			};
+			settings.State = WindowState.Minimized;
+
+			var window = new Window();
+			settings.RestoreTo(window);
+			window.Width.Should().Be(9001);
+			window.Height.Should().Be(42);
+			window.WindowState.Should().Be(WindowState.Maximized);
+		}
+
+		[Test]
 		public void TestClone([Values(true, false)] bool alwaysOnTop,
 		                      [Values(true, false)] bool isLeftSidePanelCollapsed)
 		{

--- a/src/Tailviewer/App.cs
+++ b/src/Tailviewer/App.cs
@@ -135,6 +135,7 @@ namespace Tailviewer
 		{
 			ApplicationSettings settings = ApplicationSettings.Create();
 			settings.Restore(out var neededPatching);
+			settings.AllowSave = false; //< We will allow saving once the app is fully booted
 
 			if (neededPatching)
 			{
@@ -236,6 +237,7 @@ namespace Tailviewer
 						
 						settings.MainWindow.ClipToBounds(Desktop.Current);
 						settings.MainWindow.RestoreTo(window);
+						settings.AllowSave = true;
 
 						stopwatch.Stop();
 						Log.InfoFormat("Tailviewer started (took {0}ms), showing window...", stopwatch.ElapsedMilliseconds);

--- a/src/Tailviewer/Settings/ApplicationSettings.cs
+++ b/src/Tailviewer/Settings/ApplicationSettings.cs
@@ -30,6 +30,14 @@ namespace Tailviewer.Settings
 		private readonly CustomFormatsSettings _customFormats;
 		private int _numSaved;
 
+		private bool _allowSave;
+
+		public bool AllowSave
+		{
+			get { return _allowSave; }
+			set { _allowSave = value; }
+		}
+
 		/// <summary>
 		///    How often <see cref=" SaveAsync"/> was called.
 		/// </summary>
@@ -55,6 +63,7 @@ namespace Tailviewer.Settings
 			_logViewer = other._logViewer.Clone();
 			_logFile = other._logFile.Clone();
 			_customFormats = other._customFormats.Clone();
+			_allowSave = true;
 		}
 
 		public ApplicationSettings(string fileName)
@@ -70,6 +79,7 @@ namespace Tailviewer.Settings
 			_logFile = new LogFileSettings();
 			_export = new ExportSettings();
 			_customFormats = new CustomFormatsSettings();
+			_allowSave = true;
 		}
 
 		public IAutoUpdateSettings AutoUpdate => _autoUpdate;
@@ -97,6 +107,12 @@ namespace Tailviewer.Settings
 
 		public void SaveAsync()
 		{
+			if (!AllowSave)
+			{
+				Log.DebugFormat("Saving not allow, skipping...");
+				return;
+			}
+
 			var config = Clone();
 			_saveTask = _saveTask.ContinueWith(unused => config.Save());
 			++_numSaved;

--- a/src/Tailviewer/Settings/MainWindowSettings.cs
+++ b/src/Tailviewer/Settings/MainWindowSettings.cs
@@ -14,6 +14,8 @@ namespace Tailviewer.Settings
 	{
 		private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
+		private WindowState _previousWindowState = WindowState.Normal;
+
 		public double Height
 		{
 			get { return _window.Height; }
@@ -29,7 +31,14 @@ namespace Tailviewer.Settings
 		public WindowState State
 		{
 			get { return _window.State; }
-			set { _window.State = value; }
+			set
+			{
+				if (value == _window.State)
+					return;
+
+				_previousWindowState = _window.State;
+				_window.State = value;
+			}
 		}
 
 		public double Top
@@ -80,6 +89,7 @@ namespace Tailviewer.Settings
 			writer.WriteAttributeString("selectedsidepanel", SelectedSidePanel);
 			writer.WriteAttributeBool("alwaysontop", AlwaysOnTop);
 			writer.WriteAttributeBool("isleftsidepanelvisible", IsLeftSidePanelVisible);
+			writer.WriteAttributeEnum("previouswindowstate", _previousWindowState);
 			_window.Save(writer);
 		}
 
@@ -105,6 +115,10 @@ namespace Tailviewer.Settings
 					case "selectedsidepanel":
 						SelectedSidePanel = reader.ReadContentAsString();
 						break;
+
+					case "previouswindowstate":
+						_previousWindowState = reader.ReadContentAsEnum<WindowState>();
+						break;
 				}
 			}
 
@@ -114,6 +128,16 @@ namespace Tailviewer.Settings
 		public void UpdateFrom(Window window)
 		{
 			_window.UpdateFrom(window);
+
+			// For some reason, when the window is minimized, the width and height
+			// are set to small values such as 160/28 whereas the ActualWidth and ActualHeight
+			// values are sensible. Don't know why that is, but we want to store the sensible values!
+			if (window.Width < window.ActualWidth)
+				_window.Width = window.ActualWidth;
+			if (window.Height < window.ActualHeight)
+				_window.Height = window.ActualHeight;
+
+			Log.InfoFormat("Updated main window settings to : Width={0} Height={1}", Width, Height);
 		}
 
 		public void ClipToBounds(Desktop desktop)
@@ -140,6 +164,13 @@ namespace Tailviewer.Settings
 
 		public void RestoreTo(Window window)
 		{
+			// https://github.com/Kittyfisto/Tailviewer/issues/250
+			// When we start the application, a user NEVER wants the app
+			// to start-up minimized. Therefore we start with the previous state
+			// just in case the app was minimized before it was shut-down.
+			if (_window.State == WindowState.Minimized)
+				_window.State = _previousWindowState;
+
 			_window.RestoreTo(window);
 			window.Topmost = AlwaysOnTop;
 		}


### PR DESCRIPTION
Fixes #250
Also fixed an issue where TV would store bogus width and height in case the window was minimized before TV was closed.
