### PR TITLE
Fixed bug where TV would display a non-empty log file as empty #273

### DIFF
--- a/src/Tailviewer.AcceptanceTests/BusinessLogic/LogFiles/TextLogFileAcceptanceTest.cs
+++ b/src/Tailviewer.AcceptanceTests/BusinessLogic/LogFiles/TextLogFileAcceptanceTest.cs
@@ -14,7 +14,6 @@ using log4net;
 using Tailviewer.BusinessLogic.Plugins;
 using Tailviewer.Core;
 using Tailviewer.Core.LogFiles;
-using Tailviewer.Core.Parsers;
 
 namespace Tailviewer.AcceptanceTests.BusinessLogic.LogFiles
 {

--- a/src/Tailviewer.Core/LogFiles/TextLogFile.cs
+++ b/src/Tailviewer.Core/LogFiles/TextLogFile.cs
@@ -414,11 +414,18 @@ namespace Tailviewer.Core.LogFiles
 									read = true;
 								}
 
-								var parsed = _parser?.Parse(new RawLogEntry(_entries.Count, trimmedLine));
-								Add(trimmedLine,
-								    parsed?.LogLevel ?? LevelFlags.None,
+								IReadOnlyLogEntry logEntry = new RawLogEntry(_entries.Count, trimmedLine);
+								if (_parser != null)
+								{
+									var parsedLogEntry = _parser.Parse(logEntry);
+									if (parsedLogEntry != null)
+										logEntry = parsedLogEntry;
+								}
+
+								Add(logEntry.RawContent,
+								    logEntry.LogLevel,
 								    _numberOfLinesRead,
-								    parsed?.Timestamp);
+								    logEntry.Timestamp);
 							}
 
 							_lastPosition = stream.Position;

--- a/src/Tailviewer.Test/BusinessLogic/LogFiles/Parsers/TimestampParserTest.cs
+++ b/src/Tailviewer.Test/BusinessLogic/LogFiles/Parsers/TimestampParserTest.cs
@@ -137,7 +137,7 @@ namespace Tailviewer.Test.BusinessLogic.LogFiles.Parsers
 			DateTime unused;
 			subParser.Setup(x => x.TryParse(It.IsAny<string>(), out unused)).Throws<NullReferenceException>();
 
-			new Action(() => parser.TryParse("dawwadw", out unused)).Should().NotThrow("because the parser is supposed to catch *all* exceptions thrown by buggy sub-parsers");
+			new Action(() => parser.TryParse("dawwadw1", out unused)).Should().NotThrow("because the parser is supposed to catch *all* exceptions thrown by buggy sub-parsers");
 			subParser.Verify(x => x.TryParse(It.IsAny<string>(), out unused), Times.AtLeastOnce);
 		}
 
@@ -231,6 +231,19 @@ namespace Tailviewer.Test.BusinessLogic.LogFiles.Parsers
 				.Should()
 				.BeTrue();
 			timestamp.Should().Be(new DateTime(2019, 7, 8, 16, 18, 58, 381));
+		}
+
+		[Test]
+		public void TestTryParseLongGarbageLine()
+		{
+			var parser = new TimestampParser();
+			var line = new string('\0', 158000);
+			parser
+				.TryParse(
+				          line,
+				          out _)
+				.Should()
+				.BeFalse();
 		}
 	}
 }

--- a/src/Tailviewer.Test/BusinessLogic/LogFiles/TextLogFileParserTest.cs
+++ b/src/Tailviewer.Test/BusinessLogic/LogFiles/TextLogFileParserTest.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using FluentAssertions;
+using NUnit.Framework;
+using Tailviewer.BusinessLogic.LogFiles;
+using Tailviewer.Core.LogFiles;
+using Tailviewer.Core.Parsers;
+
+namespace Tailviewer.Test.BusinessLogic.LogFiles
+{
+	[TestFixture]
+	public sealed class TextLogFileParserTest
+	{
+		[Test]
+		[Issue("https://github.com/Kittyfisto/Tailviewer/issues/273")]
+		public void TestRemoveGarbageCharacters()
+		{
+			var rawContent = "\0\0\02021-02-08 07:58:48,060 [0x000025d0] DEBUG foo Well I'll be buggered, where did those NULs come from?";
+			var parser = new TextLogFileParser(new TimestampParser());
+			var parsedLogEntry = parser.Parse(new LogEntry2 {RawContent = rawContent});
+			parsedLogEntry.RawContent.Should()
+			              .Be("2021-02-08 07:58:48,060 [0x000025d0] DEBUG foo Well I'll be buggered, where did those NULs come from?");
+			parsedLogEntry.Timestamp.Should().Be(new DateTime(2021, 2, 8, 7, 58, 48, 060));
+		}
+	}
+}

--- a/src/Tailviewer.Test/BusinessLogic/LogFiles/TextLogFileParserTest.cs
+++ b/src/Tailviewer.Test/BusinessLogic/LogFiles/TextLogFileParserTest.cs
@@ -21,5 +21,44 @@ namespace Tailviewer.Test.BusinessLogic.LogFiles
 			              .Be("2021-02-08 07:58:48,060 [0x000025d0] DEBUG foo Well I'll be buggered, where did those NULs come from?");
 			parsedLogEntry.Timestamp.Should().Be(new DateTime(2021, 2, 8, 7, 58, 48, 060));
 		}
+
+		[Test]
+		public void TestRemoveUnprintableCharacters()
+		{
+			var unprintableCharacters = new[]
+			{
+				'\0', '\u0001', '\u0002', '\u0003', '\u0004', '\u0005', '\u0006', '\a', '\b', '\n', '\v', '\f', '\r',
+				'\u000e', '\u000f', '\u0010', '\u0011', '\u0012', '\u0013', '\u0014', '\u0015', '\u0016', '\u0017', '\u0018', '\u0019', '\u001a', '\u001b', '\u001c', '\u001d', '\u001e', '\u001f',
+				'\u007f'
+			};
+			foreach (var character in unprintableCharacters)
+			{
+				var rawContent = $"Foo{character}bar";
+				var parser = new TextLogFileParser(new TimestampParser());
+				var parsedLogEntry = parser.Parse(new LogEntry2 {RawContent = rawContent});
+				parsedLogEntry.RawContent.Should()
+				              .Be("Foobar");
+			}
+		}
+
+		[Test]
+		public void TestDontRemoveTab()
+		{
+			var rawContent = "Foo\tbar";
+			var parser = new TextLogFileParser(new TimestampParser());
+			var parsedLogEntry = parser.Parse(new LogEntry2 {RawContent = rawContent});
+			parsedLogEntry.RawContent.Should()
+			              .Be("Foo\tbar");
+		}
+
+		[Test]
+		public void TestDontRemoveSpace()
+		{
+			var rawContent = "Foo bar";
+			var parser = new TextLogFileParser(new TimestampParser());
+			var parsedLogEntry = parser.Parse(new LogEntry2 {RawContent = rawContent});
+			parsedLogEntry.RawContent.Should()
+			              .Be("Foo bar");
+		}
 	}
 }

--- a/src/Tailviewer.Test/Tailviewer.Test.csproj
+++ b/src/Tailviewer.Test/Tailviewer.Test.csproj
@@ -148,6 +148,7 @@
     <Compile Include="BusinessLogic\LogFiles\PluginLogFileFactoryTest.cs" />
     <Compile Include="BusinessLogic\LogFiles\ReadOnlyLogEntriesTest.cs" />
     <Compile Include="BusinessLogic\LogFiles\ReadOnlyLogEntryTest.cs" />
+    <Compile Include="BusinessLogic\LogFiles\TextLogFileParserTest.cs" />
     <Compile Include="BusinessLogic\LogFiles\WellKnownLogFileColumnTest.cs" />
     <Compile Include="BusinessLogic\LogLineSourceIdTest.cs" />
     <Compile Include="BusinessLogic\LogLineTest.cs" />

--- a/src/Tailviewer/BusinessLogic/LogFiles/TextLogFileParser.cs
+++ b/src/Tailviewer/BusinessLogic/LogFiles/TextLogFileParser.cs
@@ -18,7 +18,8 @@ namespace Tailviewer.BusinessLogic.LogFiles
 		static TextLogFileParser()
 		{
 			// We will remove every character from ASCII [0-31] besides the tab character from the line because we can't display them anways.
-			RemovableCharacters = Enumerable.Range(0, 31).Select(x => new string((char) x, 1)).Where(y => y != "\t").ToArray();
+			RemovableCharacters = Enumerable.Range(0, 32).Select(x => new string((char) x, 1)).Where(y => y != "\t")
+			                                .Concat(new []{"\u007f"}).ToArray();
 		}
 
 		public TextLogFileParser(ITimestampParser timestampParser)

--- a/src/Tailviewer/Changelog.cs
+++ b/src/Tailviewer/Changelog.cs
@@ -55,6 +55,23 @@ namespace Tailviewer
 			AddV093();
 			AddV094();
 			AddV095();
+			AddV096();
+		}
+
+		private static void AddV096()
+		{
+			var features = new string[]
+			{};
+			var bugfixes = new string[]
+			{
+				"Tailviewer displays an empty file when the first line contains lots of garbage data [#273](https://github.com/Kittyfisto/Tailviewer/issues/273)"
+			};
+			var misc = new string[]
+			{};
+			var releaseDate = new DateTime(2021, 2, 8);
+			var version = new Version(0, 9, 6);
+			var change = new Change(releaseDate, version, features, bugfixes, misc);
+			AllChanges.Add(change);
 		}
 
 		private static void AddV095()


### PR DESCRIPTION
Fixes #273

Changes proposed in this pull request:
- TimestampParser only searches for timestamps in the first 200 characters of a line
- TimestampParser skips lines which do not contain a single digit
- TextLogFileParser strips unprintable characters (besides tab and space) from lines


Any expected problems concerning backwards compatibility of existing plugins?  
No

Any expected problems concerning backwards compatibility of existing user settings?  
No

Does this break existing user workflows?  
**Potentially:**
Users which so far have relied on having timestamps more than 200 characters from the start will no longer be able to properly merge their log files by timestamp. However I don't expect that there are any *text* log files where the timestamp is so far to the right. Either it's in the first 50 characters or the log file doesn't have a timestamp.  

Furthermore, users which have relied on ASCII characters [0-32] other than space or tab and 127 (DEL) to be printed as space will no longer be able to do so and will instead have to print a proper space or tab character. Likewise I expect the impact of this to be non-existant as it's highly unusualy to print '\0' or some other character where a space would have been appropriate.
