### PR TITLE
The empty state explicitly mentions the timestamp filter when it is active

### DIFF
--- a/src/Tailviewer.Core/Comparers/LevelFlagsComparer.cs
+++ b/src/Tailviewer.Core/Comparers/LevelFlagsComparer.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace Tailviewer.Core.Comparers
+{
+	internal sealed class LevelFlagsComparer
+		: IEqualityComparer<LevelFlags>
+	{
+		#region Implementation of IEqualityComparer<in LevelFlags>
+
+		public bool Equals(LevelFlags x, LevelFlags y)
+		{
+			return x == y;
+		}
+
+		public int GetHashCode(LevelFlags obj)
+		{
+			return obj.GetHashCode();
+		}
+
+		#endregion
+	}
+}

--- a/src/Tailviewer.Core/Filters/ExpressionEngine/BinaryOperation.cs
+++ b/src/Tailviewer.Core/Filters/ExpressionEngine/BinaryOperation.cs
@@ -5,7 +5,7 @@
 		And,
 		Or,
 		Contains,
-		ContainsTimestamp,
+		Is,
 		LessThan,
 		LessOrEquals,
 		GreaterThan,

--- a/src/Tailviewer.Core/Filters/ExpressionEngine/ContainsTimestampExpression.cs
+++ b/src/Tailviewer.Core/Filters/ExpressionEngine/ContainsTimestampExpression.cs
@@ -6,16 +6,16 @@ namespace Tailviewer.Core.Filters.ExpressionEngine
 	internal sealed class ContainsTimestampExpression
 		: IExpression<bool>
 	{
-		private readonly IExpression<DateTime?> _lhs;
-		private readonly IExpression<IInterval<DateTime?>> _rhs;
+		private readonly IExpression<IInterval<DateTime?>> _lhs;
+		private readonly IExpression<DateTime?> _rhs;
 
-		public ContainsTimestampExpression(IExpression<DateTime?> lhs, IExpression<IInterval<DateTime?>> rhs)
+		public ContainsTimestampExpression(IExpression<IInterval<DateTime?>> lhs, IExpression<DateTime?> rhs)
 		{
 			_lhs = lhs;
 			_rhs = rhs;
 		}
 
-		public static IExpression Create(IExpression<DateTime?> lhs, IExpression<IInterval<DateTime?>> rhs)
+		public static IExpression Create(IExpression<IInterval<DateTime?>> lhs, IExpression<DateTime?> rhs)
 		{
 			return new ContainsTimestampExpression(lhs, rhs);
 		}
@@ -35,21 +35,21 @@ namespace Tailviewer.Core.Filters.ExpressionEngine
 			if (rhs == null)
 				return false;
 
-			var minimum = rhs.Minimum;
-			var maximum = rhs.Maximum;
+			var minimum = lhs.Minimum;
+			var maximum = lhs.Maximum;
 
 			if (minimum == null && maximum == null)
 				return false;
 
 			if (minimum != null)
 			{
-				if (lhs < minimum)
+				if (rhs < minimum)
 					return false;
 			}
 
 			if (maximum != null)
 			{
-				if (lhs > maximum)
+				if (rhs > maximum)
 					return false;
 			}
 
@@ -89,7 +89,7 @@ namespace Tailviewer.Core.Filters.ExpressionEngine
 
 		public override string ToString()
 		{
-			return string.Format("{0} {1} {2}", _lhs, Tokenizer.ToString(TokenType.Is), _rhs);
+			return string.Format("{0} {1} {2}", _lhs, Tokenizer.ToString(TokenType.Contains), _rhs);
 		}
 
 		#endregion

--- a/src/Tailviewer.Core/Filters/ExpressionEngine/DateTimeInterval.cs
+++ b/src/Tailviewer.Core/Filters/ExpressionEngine/DateTimeInterval.cs
@@ -15,6 +15,15 @@ namespace Tailviewer.Core.Filters.ExpressionEngine
 			_maximum = maximum;
 		}
 
+		#region Overrides of Object
+
+		public override string ToString()
+		{
+			return $"({_minimum}, {_maximum})";
+		}
+
+		#endregion
+
 		#region Implementation of IExpression
 
 		public Type ResultType => typeof(IInterval<DateTime?>);

--- a/src/Tailviewer.Core/Filters/ExpressionEngine/DateTimeIntervalLiteral.cs
+++ b/src/Tailviewer.Core/Filters/ExpressionEngine/DateTimeIntervalLiteral.cs
@@ -20,7 +20,10 @@ namespace Tailviewer.Core.Filters.ExpressionEngine
 		{
 			SpecialValues = new Dictionary<string, SpecialDateTimeInterval>
 			{
-				{"today", SpecialDateTimeInterval.Today}
+				{"today", SpecialDateTimeInterval.Today},
+				{"this_week", SpecialDateTimeInterval.ThisWeek},
+				{"this_month", SpecialDateTimeInterval.ThisMonth},
+				{"this_year", SpecialDateTimeInterval.ThisYear}
 			};
 			Strings = SpecialValues.ToDictionary(pair => pair.Value, pair => pair.Key);
 		}

--- a/src/Tailviewer.Core/Filters/ExpressionEngine/ExpressionParser.cs
+++ b/src/Tailviewer.Core/Filters/ExpressionEngine/ExpressionParser.cs
@@ -23,7 +23,7 @@ namespace Tailviewer.Core.Filters.ExpressionEngine
 				{TokenType.LessOrEquals, BinaryOperation.LessOrEquals},
 				{TokenType.GreaterThan, BinaryOperation.GreaterThan},
 				{TokenType.GreaterOrEquals, BinaryOperation.GreaterOrEquals},
-				{TokenType.Is, BinaryOperation.ContainsTimestamp}
+				{TokenType.Is, BinaryOperation.Is}
 			};
 			UnaryOperations = new Bimap<TokenType, UnaryOperation>
 			{
@@ -233,6 +233,9 @@ namespace Tailviewer.Core.Filters.ExpressionEngine
 
 				case LineNumberVariable.Value:
 					return new LineNumberVariable();
+
+				case LogLevelVariable.Value:
+					return new LogLevelVariable();
 
 				case TimestampVariable.Value:
 					return new TimestampVariable();

--- a/src/Tailviewer.Core/Filters/ExpressionEngine/IsExpression.cs
+++ b/src/Tailviewer.Core/Filters/ExpressionEngine/IsExpression.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using Tailviewer.Core.Comparers;
+
+namespace Tailviewer.Core.Filters.ExpressionEngine
+{
+	internal sealed class IsExpression<T>
+		: IExpression<bool>
+	{
+		private static readonly IEqualityComparer<T> Comparer;
+		private readonly IExpression<T> _lhs;
+		private readonly IExpression<T> _rhs;
+
+		static IsExpression()
+		{
+			// The default comparer sucks for custom value types as it will cause boxing on every invocation
+			// (https://www.jacksondunstan.com/articles/5148), so we will use our own comparers for types known
+			// to us.
+			if (typeof(T) == typeof(LevelFlags))
+			{
+				Comparer = (IEqualityComparer<T>)(object)new LevelFlagsComparer();
+			}
+			else
+			{
+				Comparer = EqualityComparer<T>.Default;
+			}
+		}
+
+		public IsExpression(IExpression<T> lhs, IExpression<T> rhs)
+		{
+			_lhs = lhs;
+			_rhs = rhs;
+		}
+
+		#region Implementation of IExpression
+
+		public Type ResultType => typeof(bool);
+
+		public bool Evaluate(IReadOnlyList<IReadOnlyLogEntry> logEntry)
+		{
+			var lhs = _lhs.Evaluate(logEntry);
+			var rhs = _rhs.Evaluate(logEntry);
+
+			return Comparer.Equals(lhs, rhs);
+		}
+
+		object IExpression.Evaluate(IReadOnlyList<IReadOnlyLogEntry> logEntry)
+		{
+			return Evaluate(logEntry);
+		}
+
+		#endregion
+
+		#region Equality members
+
+		private bool Equals(IsExpression<T> other)
+		{
+			return Equals(_lhs, other._lhs) && Equals(_rhs, other._rhs);
+		}
+
+		public override bool Equals(object obj)
+		{
+			return ReferenceEquals(this, obj) || obj is IsExpression<T> other && Equals(other);
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				return ((_lhs != null ? _lhs.GetHashCode() : 0) * 397) ^ (_rhs != null ? _rhs.GetHashCode() : 0);
+			}
+		}
+
+		public static bool operator ==(IsExpression<T> left, IsExpression<T> right)
+		{
+			return Equals(left, right);
+		}
+
+		public static bool operator !=(IsExpression<T> left, IsExpression<T> right)
+		{
+			return !Equals(left, right);
+		}
+
+		#endregion
+
+		#region Overrides of Object
+
+		public override string ToString()
+		{
+			return string.Format("{0} {1} {2}", _lhs, Tokenizer.ToString(TokenType.Is), _rhs);
+		}
+
+		#endregion
+
+		[Pure]
+		public static IsExpression<T> Create(IExpression<T> lhs, IExpression<T> rhs)
+		{
+			return new IsExpression<T>(lhs, rhs);
+		}
+	}
+}

--- a/src/Tailviewer.Core/Filters/ExpressionEngine/Literal.cs
+++ b/src/Tailviewer.Core/Filters/ExpressionEngine/Literal.cs
@@ -22,6 +22,9 @@ namespace Tailviewer.Core.Filters.ExpressionEngine
 			if (DateTimeIntervalLiteral.TryParse(value, out var dateTimeLiteral))
 				return new DateTimeIntervalLiteral(dateTimeLiteral);
 
+			if (LogLevelLiteral.TryParse(value, out var logLevel))
+				return new LogLevelLiteral(logLevel);
+
 			if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var integerValue))
 				return new IntegerLiteral(integerValue);
 

--- a/src/Tailviewer.Core/Filters/ExpressionEngine/LogLevelLiteral.cs
+++ b/src/Tailviewer.Core/Filters/ExpressionEngine/LogLevelLiteral.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Tailviewer.Core.Filters.ExpressionEngine
+{
+	internal sealed class LogLevelLiteral
+		: IExpression<LevelFlags>
+	{
+		private static readonly IReadOnlyDictionary<string, LevelFlags> LogLevels;
+
+		private readonly LevelFlags _logLevel;
+
+		static LogLevelLiteral()
+		{
+			LogLevels = new Dictionary<string, LevelFlags>
+			{
+				{"fatal", LevelFlags.Fatal},
+				{"error", LevelFlags.Error},
+				{"warning", LevelFlags.Warning},
+				{"info", LevelFlags.Info},
+				{"debug", LevelFlags.Debug},
+				{"trace", LevelFlags.Trace},
+				{"other", LevelFlags.Other}
+			};
+		}
+
+		public LogLevelLiteral(LevelFlags logLevel)
+		{
+			_logLevel = logLevel;
+		}
+
+		#region Implementation of IExpression
+
+		public Type ResultType => typeof(LevelFlags);
+
+		public LevelFlags Evaluate(IReadOnlyList<IReadOnlyLogEntry> logEntry)
+		{
+			return _logLevel;
+		}
+
+		object IExpression.Evaluate(IReadOnlyList<IReadOnlyLogEntry> logEntry)
+		{
+			return Evaluate(logEntry);
+		}
+
+		#endregion
+
+		#region Equality members
+
+		private bool Equals(LogLevelLiteral other)
+		{
+			return _logLevel == other._logLevel;
+		}
+
+		public override bool Equals(object obj)
+		{
+			return ReferenceEquals(this, obj) || obj is LogLevelLiteral other && Equals(other);
+		}
+
+		public override int GetHashCode()
+		{
+			return (int) _logLevel;
+		}
+
+		public static bool operator ==(LogLevelLiteral left, LogLevelLiteral right)
+		{
+			return Equals(left, right);
+		}
+
+		public static bool operator !=(LogLevelLiteral left, LogLevelLiteral right)
+		{
+			return !Equals(left, right);
+		}
+
+		#endregion
+
+		#region Overrides of Object
+
+		public override string ToString()
+		{
+			return _logLevel.ToString();
+		}
+
+		#endregion
+
+		public static bool TryParse(string value, out LevelFlags logLevel)
+		{
+			foreach (var pair in LogLevels)
+			{
+				if (string.Equals(pair.Key, value, StringComparison.InvariantCultureIgnoreCase))
+				{
+					logLevel = pair.Value;
+					return true;
+				}
+			}
+
+			logLevel = LevelFlags.None;
+			return false;
+		}
+	}
+}

--- a/src/Tailviewer.Core/Filters/ExpressionEngine/LogLevelVariable.cs
+++ b/src/Tailviewer.Core/Filters/ExpressionEngine/LogLevelVariable.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Tailviewer.Core.Filters.ExpressionEngine
+{
+	internal sealed class LogLevelVariable
+		: IExpression<LevelFlags>
+	{
+		public const string Value = "loglevel";
+
+		#region Implementation of IExpression
+
+		public Type ResultType => typeof(LevelFlags);
+
+		public LevelFlags Evaluate(IReadOnlyList<IReadOnlyLogEntry> logEntry)
+		{
+			using (var it = logEntry.GetEnumerator())
+			{
+				if (!it.MoveNext())
+					return LevelFlags.None;
+
+				return it.Current.LogLevel;
+			}
+		}
+
+		object IExpression.Evaluate(IReadOnlyList<IReadOnlyLogEntry> logEntry)
+		{
+			return Evaluate(logEntry);
+		}
+
+		#endregion
+
+		#region Overrides of Object
+
+		public override bool Equals(object obj)
+		{
+			return obj is LogLevelVariable;
+		}
+
+		public override int GetHashCode()
+		{
+			return 106;
+		}
+
+		public override string ToString()
+		{
+			return string.Format("{0}{1}", Tokenizer.ToString(TokenType.Dollar), Value);
+		}
+
+		#endregion
+	}
+}

--- a/src/Tailviewer.Core/Filters/FilterExpression.cs
+++ b/src/Tailviewer.Core/Filters/FilterExpression.cs
@@ -33,6 +33,16 @@ namespace Tailviewer.Core.Filters
 			return new FilterExpression(expr);
 		}
 
+		#region Overrides of Object
+
+		/// <inheritdoc />
+		public override string ToString()
+		{
+			return _expression.ToString();
+		}
+
+		#endregion
+
 		#region Implementation of ILogLineFilter
 
 		/// <inheritdoc />

--- a/src/Tailviewer.Core/Settings/TimeFilter.cs
+++ b/src/Tailviewer.Core/Settings/TimeFilter.cs
@@ -116,7 +116,7 @@ namespace Tailviewer.Core.Settings
 			if (interval == null)
 				return null;
 
-			var expression = new ContainsTimestampExpression(new TimestampVariable(), interval);
+			var expression = new ContainsTimestampExpression(interval, new TimestampVariable());
 			return new FilterExpression(expression);
 		}
 

--- a/src/Tailviewer.Core/Tailviewer.Core.csproj
+++ b/src/Tailviewer.Core/Tailviewer.Core.csproj
@@ -79,6 +79,10 @@
     <Compile Include="Filters\ExpressionEngine\ContainsStringExpression.cs" />
     <Compile Include="Filters\ExpressionEngine\DateTimeInterval.cs" />
     <Compile Include="Filters\ExpressionEngine\DateTimeLiteral.cs" />
+    <Compile Include="Filters\ExpressionEngine\IsExpression.cs" />
+    <Compile Include="Comparers\LevelFlagsComparer.cs" />
+    <Compile Include="Filters\ExpressionEngine\LogLevelLiteral.cs" />
+    <Compile Include="Filters\ExpressionEngine\LogLevelVariable.cs" />
     <Compile Include="Filters\RangeFilter.cs" />
     <Compile Include="DisposableExtensions.cs" />
     <Compile Include="Buffers\SingleColumnLogBufferView.cs" />

--- a/src/Tailviewer.Test/BusinessLogic/Filters/ExpressionEngine/ContainsTimestampExpressionTest.cs
+++ b/src/Tailviewer.Test/BusinessLogic/Filters/ExpressionEngine/ContainsTimestampExpressionTest.cs
@@ -12,16 +12,16 @@ namespace Tailviewer.Test.BusinessLogic.Filters.ExpressionEngine
 		[Test]
 		public void TestEvaluateNullTimestamp()
 		{
-			var expression = new ContainsTimestampExpression(new DateTimeLiteral(null),
-			                                                 new DateTimeIntervalLiteral(SpecialDateTimeInterval.Today));
+			var expression = new ContainsTimestampExpression(new DateTimeIntervalLiteral(SpecialDateTimeInterval.Today),
+			                                                 new DateTimeLiteral(null));
 			expression.Evaluate(null).Should().BeFalse("because a null timestamp is not part of any interval");
 		}
 
 		[Test]
 		public void TestEvaluateNullInterval()
 		{
-			var expression = new ContainsTimestampExpression(new DateTimeLiteral(DateTime.Now),
-			                                                 new DateTimeInterval(null, null));
+			var expression = new ContainsTimestampExpression(new DateTimeInterval(null, null),
+			                                                 new DateTimeLiteral(DateTime.Now));
 			expression.Evaluate(null).Should().BeFalse("because nothing can be part of a null interval");
 		}
 
@@ -29,7 +29,7 @@ namespace Tailviewer.Test.BusinessLogic.Filters.ExpressionEngine
 		public void TestEvaluateOnlyStart1()
 		{
 			var start = new DateTime(2018, 8, 1, 0, 0, 0);
-			var expression = new ContainsTimestampExpression(new DateTimeLiteral(start), new DateTimeInterval(start, null));
+			var expression = new ContainsTimestampExpression(new DateTimeInterval(start, null), new DateTimeLiteral(start));
 			expression.Evaluate(null).Should().BeTrue("because the specified timestamp is equal to start");
 		}
 
@@ -37,7 +37,7 @@ namespace Tailviewer.Test.BusinessLogic.Filters.ExpressionEngine
 		public void TestEvaluateOnlyStart2()
 		{
 			var start = new DateTime(2018, 8, 1, 0, 0, 0);
-			var expression = new ContainsTimestampExpression(new DateTimeLiteral(start - TimeSpan.FromTicks(1)), new DateTimeInterval(start, null));
+			var expression = new ContainsTimestampExpression(new DateTimeInterval(start, null), new DateTimeLiteral(start - TimeSpan.FromTicks(1)));
 			expression.Evaluate(null).Should().BeFalse("because the specified timestamp is less than start");
 		}
 
@@ -45,7 +45,7 @@ namespace Tailviewer.Test.BusinessLogic.Filters.ExpressionEngine
 		public void TestEvaluateOnlyStart3()
 		{
 			var start = new DateTime(2018, 8, 1, 0, 0, 0);
-			var expression = new ContainsTimestampExpression(new DateTimeLiteral(start + TimeSpan.FromTicks(1)), new DateTimeInterval(start, null));
+			var expression = new ContainsTimestampExpression(new DateTimeInterval(start, null), new DateTimeLiteral(start + TimeSpan.FromTicks(1)));
 			expression.Evaluate(null).Should().BeTrue("because the specified timestamp is greater than start");
 		}
 
@@ -53,7 +53,7 @@ namespace Tailviewer.Test.BusinessLogic.Filters.ExpressionEngine
 		public void TestEvaluateOnlyEnd1()
 		{
 			var end = new DateTime(2018, 8, 1, 0, 0, 0);
-			var expression = new ContainsTimestampExpression(new DateTimeLiteral(end), new DateTimeInterval(null, end));
+			var expression = new ContainsTimestampExpression(new DateTimeInterval(null, end), new DateTimeLiteral(end));
 			expression.Evaluate(null).Should().BeTrue("because the specified timestamp is equal to end");
 		}
 
@@ -61,7 +61,7 @@ namespace Tailviewer.Test.BusinessLogic.Filters.ExpressionEngine
 		public void TestEvaluateOnlyEnd2()
 		{
 			var end = new DateTime(2018, 8, 1, 0, 0, 0);
-			var expression = new ContainsTimestampExpression(new DateTimeLiteral(end - TimeSpan.FromTicks(1)), new DateTimeInterval(null, end));
+			var expression = new ContainsTimestampExpression(new DateTimeInterval(null, end), new DateTimeLiteral(end - TimeSpan.FromTicks(1)));
 			expression.Evaluate(null).Should().BeTrue("because the specified timestamp is less than end");
 		}
 
@@ -69,7 +69,7 @@ namespace Tailviewer.Test.BusinessLogic.Filters.ExpressionEngine
 		public void TestEvaluateOnlyEnd3()
 		{
 			var end = new DateTime(2018, 8, 1, 0, 0, 0);
-			var expression = new ContainsTimestampExpression(new DateTimeLiteral(end + TimeSpan.FromTicks(1)), new DateTimeInterval(null, end));
+			var expression = new ContainsTimestampExpression(new DateTimeInterval(null, end), new DateTimeLiteral(end + TimeSpan.FromTicks(1)));
 			expression.Evaluate(null).Should().BeFalse("because the specified timestamp is greater than end");
 		}
 	}

--- a/src/Tailviewer.Test/BusinessLogic/Filters/ExpressionEngine/ExpressionParserTest.cs
+++ b/src/Tailviewer.Test/BusinessLogic/Filters/ExpressionEngine/ExpressionParserTest.cs
@@ -103,8 +103,28 @@ namespace Tailviewer.Test.BusinessLogic.Filters.ExpressionEngine
 		[Test]
 		public void TestParseTimestampIsToday()
 		{
-			Parse("$timestamp is today")
-				.Should().Be(new ContainsTimestampExpression(new TimestampVariable(), new DateTimeIntervalLiteral(SpecialDateTimeInterval.Today)));
+			Parse("today contains $timestamp")
+				.Should().Be(new ContainsTimestampExpression(new DateTimeIntervalLiteral(SpecialDateTimeInterval.Today), new TimestampVariable()));
+		}
+
+		[Test]
+		public void TestParseLogLevel()
+		{
+			Parse("$loglevel").Should().Be(new LogLevelVariable());
+		}
+
+		[Test]
+		public void TestParseLogLevelLiteralError()
+		{
+			Parse("error")
+				.Should().Be(new LogLevelLiteral(LevelFlags.Error));
+		}
+
+		[Test]
+		public void TestParseLogLevelIsError()
+		{
+			Parse("$loglevel is error")
+				.Should().Be(new IsExpression<LevelFlags>(new LogLevelVariable(), new LogLevelLiteral(LevelFlags.Error)));
 		}
 
 		[Test]

--- a/src/Tailviewer.Test/BusinessLogic/Filters/ExpressionEngine/FilterExpressionTest.cs
+++ b/src/Tailviewer.Test/BusinessLogic/Filters/ExpressionEngine/FilterExpressionTest.cs
@@ -20,5 +20,12 @@ namespace Tailviewer.Test.BusinessLogic.Filters.ExpressionEngine
 			expression.PassesFilter(new LogEntry(GeneralColumns.Minimum){LineNumber = 5001})
 			          .Should().BeTrue();
 		}
+
+		[Test]
+		public void TestToString()
+		{
+			var expression = FilterExpression.Parse("$linenumber > 5000");
+			expression.ToString().Should().Be("$linenumber > 5000");
+		}
 	}
 }

--- a/src/Tailviewer.Test/BusinessLogic/Filters/ExpressionEngine/LogLevelLiteralTest.cs
+++ b/src/Tailviewer.Test/BusinessLogic/Filters/ExpressionEngine/LogLevelLiteralTest.cs
@@ -1,0 +1,66 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Tailviewer.Core.Filters.ExpressionEngine;
+
+namespace Tailviewer.Test.BusinessLogic.Filters.ExpressionEngine
+{
+	[TestFixture]
+	public sealed class LogLevelLiteralTest
+	{
+		[Test]
+		public void TestTryParseFatal([Values("fatal", "FATAL", "Fatal")] string value)
+		{
+			LogLevelLiteral.TryParse(value, out var logLevel).Should().BeTrue();
+			logLevel.Should().Be(LevelFlags.Fatal);
+		}
+
+		[Test]
+		public void TestTryParseError([Values("error", "ERROR", "Error")] string value)
+		{
+			LogLevelLiteral.TryParse(value, out var logLevel).Should().BeTrue();
+			logLevel.Should().Be(LevelFlags.Error);
+		}
+
+		[Test]
+		public void TestTryParseWarning([Values("warning", "WARNING", "Warning")] string value)
+		{
+			LogLevelLiteral.TryParse(value, out var logLevel).Should().BeTrue();
+			logLevel.Should().Be(LevelFlags.Warning);
+		}
+
+		[Test]
+		public void TestTryParseInfo([Values("info", "INFO", "Info")] string value)
+		{
+			LogLevelLiteral.TryParse(value, out var logLevel).Should().BeTrue();
+			logLevel.Should().Be(LevelFlags.Info);
+		}
+
+		[Test]
+		public void TestTryParseDebug([Values("debug", "DEBUG", "Debug")] string value)
+		{
+			LogLevelLiteral.TryParse(value, out var logLevel).Should().BeTrue();
+			logLevel.Should().Be(LevelFlags.Debug);
+		}
+
+		[Test]
+		public void TestTryParseTrace([Values("trace", "TRACE", "Trace")] string value)
+		{
+			LogLevelLiteral.TryParse(value, out var logLevel).Should().BeTrue();
+			logLevel.Should().Be(LevelFlags.Trace);
+		}
+
+		[Test]
+		public void TestTryParseNone([Values("other", "OTHER", "Other")] string value)
+		{
+			LogLevelLiteral.TryParse(value, out var logLevel).Should().BeTrue();
+			logLevel.Should().Be(LevelFlags.Other);
+		}
+
+		[Test]
+		public void TestTryParseUnknown([Values("swdwd", "", null)] string value)
+		{
+			LogLevelLiteral.TryParse(value, out var logLevel).Should().BeFalse();
+			logLevel.Should().Be(LevelFlags.None);
+		}
+	}
+}

--- a/src/Tailviewer.Test/BusinessLogic/Filters/ExpressionEngine/TokenizerTest.cs
+++ b/src/Tailviewer.Test/BusinessLogic/Filters/ExpressionEngine/TokenizerTest.cs
@@ -13,5 +13,25 @@ namespace Tailviewer.Test.BusinessLogic.Filters.ExpressionEngine
 			var tokenizer = new Tokenizer();
 			tokenizer.Tokenize("\"").Should().Equal(new Token(TokenType.Quotation));
 		}
+
+		[Test]
+		[Description("Verifies that the tokenizer does not split singular word literals just because the word consists partially of another token type such as 'Or'")]
+		public void TestParseLogLevelLiteral()
+		{
+			var tokenizer = new Tokenizer();
+			tokenizer.Tokenize("error").Should().Equal(new Token(TokenType.Literal, "error"));
+		}
+
+		[Test]
+		public void TestParseSimpleExpression()
+		{
+			var tokenizer = new Tokenizer();
+			tokenizer.Tokenize("$loglevel is fatal").Should().Equal(new Token(TokenType.Dollar),
+			                                                        new Token(TokenType.Literal, "loglevel"),
+			                                                        new Token(TokenType.Whitespace, " "),
+			                                                        new Token(TokenType.Is),
+			                                                        new Token(TokenType.Whitespace, " "),
+			                                                        new Token(TokenType.Literal, "fatal"));
+		}
 	}
 }

--- a/src/Tailviewer.Test/Tailviewer.Test.csproj
+++ b/src/Tailviewer.Test/Tailviewer.Test.csproj
@@ -107,6 +107,7 @@
     <Compile Include="BusinessLogic\Filters\ExpressionEngine\ExpressionParserErrorTest.cs" />
     <Compile Include="BusinessLogic\Filters\ExpressionEngine\ExpressionParserTest.cs" />
     <Compile Include="BusinessLogic\Filters\ExpressionEngine\FilterExpressionTest.cs" />
+    <Compile Include="BusinessLogic\Filters\ExpressionEngine\LogLevelLiteralTest.cs" />
     <Compile Include="BusinessLogic\Filters\ExpressionEngine\TokenizerTest.cs" />
     <Compile Include="BusinessLogic\Filters\FilterTest.cs" />
     <Compile Include="BusinessLogic\Filters\LevelFilterTest.cs" />

--- a/src/Tailviewer.Test/Ui/LogViewerViewModelTest.cs
+++ b/src/Tailviewer.Test/Ui/LogViewerViewModelTest.cs
@@ -220,6 +220,29 @@ namespace Tailviewer.Test.Ui
 		}
 
 		[Test]
+		[Issue("https://github.com/Kittyfisto/Tailviewer/issues/307")]
+		public void TestTimeFilter()
+		{
+			var dataSource = new Mock<IFileDataSource>();
+			var logFile = new Mock<ILogSource>();
+			logFile.Setup(x => x.GetProperty(GeneralProperties.EmptyReason)).Returns(ErrorFlags.None);
+			logFile.Setup(x => x.GetProperty(GeneralProperties.LogEntryCount)).Returns(1);
+			logFile.Setup(x => x.GetProperty(GeneralProperties.Size)).Returns(Size.FromBytes(1));
+			var filteredLogFile = new Mock<ILogSource>();
+			dataSource.Setup(x => x.UnfilteredLogSource).Returns(logFile.Object);
+			dataSource.Setup(x => x.FilteredLogSource).Returns(filteredLogFile.Object);
+			dataSource.Setup(x => x.LogEntryFilter).Returns(FilterExpression.Parse("today contains $timestamp"));
+			dataSource.Setup(x => x.LevelFilter).Returns(LevelFlags.All);
+			dataSource.Setup(x => x.Search).Returns(new Mock<ILogSourceSearch>().Object);
+
+			var dataSourceModel = CreateFileViewModel(dataSource.Object);
+			var model = new LogViewerViewModel(dataSourceModel, _actionCenter.Object, _settings.Object, TimeSpan.Zero);
+			model.LogEntryCount.Should().Be(0);
+			model.NoEntriesExplanation.Should().Be("Nothing matches quick filter");
+			model.NoEntriesAction.Should().Be("No log entry matches \"today contains $timestamp\".\r\nTry changing your filter(s) or disable them again");
+		}
+
+		[Test]
 		public void TestDataSourceNoFiles()
 		{
 			var dataSource = new Mock<IFolderDataSource>();
@@ -259,6 +282,7 @@ namespace Tailviewer.Test.Ui
 		}
 
 		[Test]
+		[Issue("https://github.com/Kittyfisto/Tailviewer/issues/308")]
 		public void TestScreenCleared()
 		{
 			var dataSource = new Mock<IFileDataSource>();

--- a/src/Tailviewer.Test/Ui/LogViewerViewModelTest.cs
+++ b/src/Tailviewer.Test/Ui/LogViewerViewModelTest.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using Tailviewer.BusinessLogic.ActionCenter;
 using Tailviewer.BusinessLogic.DataSources;
 using Tailviewer.BusinessLogic.Searches;
+using Tailviewer.Core.Filters;
 using Tailviewer.Core.Properties;
 using Tailviewer.Settings;
 using Tailviewer.Ui.DataSourceTree;
@@ -185,7 +186,7 @@ namespace Tailviewer.Test.Ui
 			dataSource.Setup(x => x.UnfilteredLogSource).Returns(logFile.Object);
 			dataSource.Setup(x => x.FilteredLogSource).Returns(filteredLogFile.Object);
 			dataSource.Setup(x => x.SearchTerm).Returns("");
-			dataSource.Setup(x => x.QuickFilterChain).Returns(new List<ILogEntryFilter> {new Mock<ILogEntryFilter>().Object});
+			dataSource.Setup(x => x.LogEntryFilter).Returns(new SubstringFilter("foo", true));
 			dataSource.Setup(x => x.LevelFilter).Returns(LevelFlags.All);
 			dataSource.Setup(x => x.Search).Returns(new Mock<ILogSourceSearch>().Object);
 
@@ -207,7 +208,7 @@ namespace Tailviewer.Test.Ui
 			var filteredLogFile = new Mock<ILogSource>();
 			dataSource.Setup(x => x.UnfilteredLogSource).Returns(logFile.Object);
 			dataSource.Setup(x => x.FilteredLogSource).Returns(filteredLogFile.Object);
-			dataSource.Setup(x => x.SearchTerm).Returns("s");
+			dataSource.Setup(x => x.LogEntryFilter).Returns(new SubstringFilter("s", true));
 			dataSource.Setup(x => x.LevelFilter).Returns(LevelFlags.All);
 			dataSource.Setup(x => x.Search).Returns(new Mock<ILogSourceSearch>().Object);
 

--- a/src/Tailviewer.Test/Ui/QuickFiltersSidePanelViewModelTest.cs
+++ b/src/Tailviewer.Test/Ui/QuickFiltersSidePanelViewModelTest.cs
@@ -164,16 +164,20 @@ namespace Tailviewer.Test.Ui
 		public void TestChangeTimeFilter()
 		{
 			var model = new QuickFiltersSidePanelViewModel(_settings, _quickFilters);
+			model.QuickInfo.Should().BeNull();
 			model.TimeFilters.SelectBySpecialInterval = true;
 
 			var numFilterChanges = 0;
 			model.OnFiltersChanged += () => ++numFilterChanges;
+			model.QuickInfo.Should().Be("1 active");
 
 			model.TimeFilters.SelectedSpecialInterval = new SpecialTimeRangeViewModel(SpecialDateTimeInterval.ThisYear);
 			numFilterChanges.Should().Be(1, "because we've made a change to the selected time range");
+			model.QuickInfo.Should().Be("1 active");
 
 			model.TimeFilters.SelectEverything = true;
 			numFilterChanges.Should().Be(2, "because we've made a 2nd change to the selected time range");
+			model.QuickInfo.Should().BeNull();
 		}
 
 		[Test]

--- a/src/Tailviewer/BusinessLogic/DataSources/AbstractDataSource.cs
+++ b/src/Tailviewer/BusinessLogic/DataSources/AbstractDataSource.cs
@@ -28,6 +28,7 @@ namespace Tailviewer.BusinessLogic.DataSources
 		private readonly LogSourceProxy _findAllLogSource;
 		private readonly LogSourceSearchProxy _findAllSearch;
 
+		private ILogEntryFilter _logEntryFilter;
 		private ILogSource _filteredLogSource;
 		private IEnumerable<ILogEntryFilter> _quickFilterChain;
 		private bool _isDisposed;
@@ -69,6 +70,8 @@ namespace Tailviewer.BusinessLogic.DataSources
 		public ILogSourceSearch Search => _search;
 
 		public abstract IPluginDescription TranslationPlugin { get; }
+
+		public ILogEntryFilter LogEntryFilter => _logEntryFilter;
 
 		public IEnumerable<ILogEntryFilter> QuickFilterChain
 		{
@@ -334,11 +337,13 @@ namespace Tailviewer.BusinessLogic.DataSources
 			ILogEntryFilter logEntryFilter = Filter.Create(levelFilter, _quickFilterChain);
 			if (Filter.IsFilter(logEntryFilter) || Filter.IsFilter(logLineFilter))
 			{
+				_logEntryFilter = logEntryFilter;
 				_filteredLogSource = UnfilteredLogSource.AsFiltered(_taskScheduler, logLineFilter, logEntryFilter, _maximumWaitTime);
 				_logSource.InnerLogSource = _filteredLogSource;
 			}
 			else
 			{
+				_logEntryFilter = null;
 				_filteredLogSource = null;
 				_logSource.InnerLogSource = UnfilteredLogSource;
 			}

--- a/src/Tailviewer/BusinessLogic/DataSources/FolderDataSource.cs
+++ b/src/Tailviewer/BusinessLogic/DataSources/FolderDataSource.cs
@@ -111,6 +111,8 @@ namespace Tailviewer.BusinessLogic.DataSources
 			}
 		}
 
+		public ILogEntryFilter LogEntryFilter => _mergedDataSource.LogEntryFilter;
+
 		public ILogSource OriginalLogSource
 		{
 			get { return _mergedDataSource.OriginalLogSource; }

--- a/src/Tailviewer/BusinessLogic/DataSources/IDataSource.cs
+++ b/src/Tailviewer/BusinessLogic/DataSources/IDataSource.cs
@@ -24,6 +24,14 @@ namespace Tailviewer.BusinessLogic.DataSources
 		IEnumerable<ILogEntryFilter> QuickFilterChain { get; set; }
 
 		/// <summary>
+		///     The final filter which is used to filter the <see cref="UnfilteredLogSource"/> into the <see cref="FilteredLogSource"/>.
+		/// </summary>
+		/// <remarks>
+		///     Is an amalgamation of <see cref="QuickFilterChain"/>, <see cref="LevelFilter"/>, <see cref="ClearScreen"/>, etc...
+		/// </remarks>
+		ILogEntryFilter LogEntryFilter { get; }
+
+		/// <summary>
 		///     The actual log file this source eventually represents,
 		///     WITHOUT any of the settings of this source applied
 		///     (such as multiline, filters, etc...).

--- a/src/Tailviewer/Ui/LogView/LogViewerControl.xaml
+++ b/src/Tailviewer/Ui/LogView/LogViewerControl.xaml
@@ -245,7 +245,7 @@
                       Visibility="{Binding ErrorMessage, ElementName=This, Converter={StaticResource NullToCollapsedConverter}}"
                       HorizontalAlignment="Center"
                       VerticalAlignment="Center"
-                      Width="300"
+                      Width="310"
                       Margin="20">
                     <Grid.RowDefinitions>
                         <RowDefinition />

--- a/src/Tailviewer/Ui/LogView/LogViewerViewModel.cs
+++ b/src/Tailviewer/Ui/LogView/LogViewerViewModel.cs
@@ -13,6 +13,7 @@ using Tailviewer.BusinessLogic.ActionCenter;
 using Tailviewer.BusinessLogic.DataSources;
 using Tailviewer.BusinessLogic.Exporter;
 using Tailviewer.BusinessLogic.Searches;
+using Tailviewer.Core.Filters;
 using Tailviewer.Core.Properties;
 using Tailviewer.Core.Sources.Merged;
 using Tailviewer.Settings;
@@ -263,7 +264,7 @@ namespace Tailviewer.Ui.LogView
 
 			if (filtered.GetProperty(GeneralProperties.LogEntryCount) == 0)
 			{
-				IEnumerable<ILogEntryFilter> chain = dataSource.QuickFilterChain;
+				ILogEntryFilter filter = dataSource.LogEntryFilter;
 				var emptyReason = source.GetProperty(GeneralProperties.EmptyReason);
 				if ((emptyReason & ErrorFlags.SourceDoesNotExist) == ErrorFlags.SourceDoesNotExist)
 				{
@@ -307,11 +308,13 @@ namespace Tailviewer.Ui.LogView
 					NoEntriesExplanation = "The screen was cleared";
 					NoEntriesAction = "No new log entries have been added to the data source since the screen was cleared. Try waiting for a little longer or show all log entries again.";
 				}
-				else if (chain != null && chain.All(x => x != null))
+				else if (filter != null)
 				{
 					NoEntriesIcon = Icons.FileSearch;
 					NoEntriesExplanation = "Nothing matches quick filter";
-					NoEntriesAction = "Try filtering by different terms or disable all quick filters";
+					NoEntriesAction = filter is FilterExpression
+						? $"No log entry matches \"{filter}\".\r\nTry changing your filter(s) or disable them again"
+						: "Try filtering by different terms or disable all quick filters";
 				}
 				else if (source is MergedLogSource)
 				{

--- a/src/Tailviewer/Ui/SidePanel/QuickFilters/QuickFiltersSidePanelViewModel.cs
+++ b/src/Tailviewer/Ui/SidePanel/QuickFilters/QuickFiltersSidePanelViewModel.cs
@@ -124,6 +124,9 @@ namespace Tailviewer.Ui.SidePanel.QuickFilters
 		private void OnOnFiltersChanged()
 		{
 			var count = QuickFilters.Count(x => x.IsActive);
+			if (!TimeFilters.SelectEverything)
+				++count;
+
 			QuickInfo = count > 0 ? string.Format("{0} active", count) : null;
 			OnFiltersChanged?.Invoke();
 		}

--- a/src/Tailviewer/Ui/SidePanel/QuickFilters/TimeFilter/TimeChooserControl.xaml
+++ b/src/Tailviewer/Ui/SidePanel/QuickFilters/TimeFilter/TimeChooserControl.xaml
@@ -13,6 +13,7 @@
 
     <UserControl.Resources>
         <converters:BoolFalseToCollapsedConverter x:Key="BoolFalseToCollapsedConverter" />
+        <converters:BoolTrueToHiddenConverter x:Key="BoolTrueToHiddenConverter" />
     </UserControl.Resources>
 
     <Grid>
@@ -28,13 +29,15 @@
                     <ColumnDefinition />
                 </Grid.ColumnDefinitions>
 
-                <Viewbox Width="20" Height="20">
+                <Viewbox Width="20" Height="20"
+                         Visibility="{Binding SelectEverything, Converter={StaticResource BoolTrueToHiddenConverter}}">
                     <Canvas Width="24" Height="24">
                         <Path
                             Data="M12,20A8,8 0 0,0 20,12A8,8 0 0,0 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22C6.47,22 2,17.5 2,12A10,10 0 0,1 12,2M12.5,7V12.25L17,14.92L16.25,16.15L11,13V7H12.5Z"
                             Fill="{Binding Foreground, ElementName=PART_TimeFilterTitle}" />
                     </Canvas>
                 </Viewbox>
+
                 <controls:FlatTextBlock Grid.Column="1"
                                         Margin="4,0,0,0"
                                         VerticalAlignment="Center"


### PR DESCRIPTION
Fixes #307

- [x] The quick filter side panel model counts a selected time range as an active filter
- [x] The clock next to the time range filter is hidden when the filter isn't set to everything

![image](https://user-images.githubusercontent.com/11990827/109425132-29c33f80-79e7-11eb-90b9-b9f09523226d.png)
![image](https://user-images.githubusercontent.com/11990827/109425136-30ea4d80-79e7-11eb-9ad5-8d0f9e7b33b4.png)
