### PR TITLE
Fixed bug where neither LogSourceSearch nor MergedLogSource were dealing correctly with invalidations

### DIFF
--- a/Tailviewer.sln.DotSettings
+++ b/Tailviewer.sln.DotSettings
@@ -7,6 +7,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=datagrams/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=endian/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Flyout/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Invalidations/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Metrolib/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mie_00DFler/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=mylog/@EntryIndexedValue">True</s:Boolean>

--- a/src/Tailviewer.AcceptanceTests/BusinessLogic/Sources/MergedLogSourceTest.cs
+++ b/src/Tailviewer.AcceptanceTests/BusinessLogic/Sources/MergedLogSourceTest.cs
@@ -9,7 +9,6 @@ using Tailviewer.Core.Columns;
 using Tailviewer.Core.Properties;
 using Tailviewer.Core.Sources;
 using Tailviewer.Core.Sources.Merged;
-using Tailviewer.Core.Sources.Text;
 using Tailviewer.Core.Sources.Text.Simple;
 using Tailviewer.Test;
 

--- a/src/Tailviewer.Api/LogFileSection.cs
+++ b/src/Tailviewer.Api/LogFileSection.cs
@@ -37,6 +37,9 @@ namespace Tailviewer
 		/// Whether or not this section represents an addition (=False)
 		/// or an invalidation (i.e. Removal, True).
 		/// </summary>
+		/// <remarks>
+		///    TODO: Rename to IsRemove because that's what it's supposed to imply
+		/// </remarks>
 		public readonly bool IsInvalidate;
 
 		static LogFileSection()

--- a/src/Tailviewer.Core/Sources/Merged/MergedLogSourceIndex.cs
+++ b/src/Tailviewer.Core/Sources/Merged/MergedLogSourceIndex.cs
@@ -282,11 +282,20 @@ namespace Tailviewer.Core.Sources.Merged
 					var firstIndex = _indices.FindIndex(x => x.SourceId == logFileIndex);
 					if (firstIndex >= 0)
 					{
-						changes.InvalidateFrom(firstIndex);
 						_indices.RemoveAll(x => x.SourceId == logFileIndex);
 						if (_indices.Count == 0)
 						{
 							changes.Reset();
+						}
+						else
+						{
+							changes.InvalidateFrom(firstIndex);
+
+							var appendCount = _indices.Count - firstIndex;
+							if (appendCount > 0)
+							{
+								changes.Append(firstIndex, appendCount);
+							}
 						}
 					}
 				}

--- a/src/Tailviewer.Core/Sources/Text/Streaming/StreamingTextLogSource.cs
+++ b/src/Tailviewer.Core/Sources/Text/Streaming/StreamingTextLogSource.cs
@@ -339,16 +339,6 @@ namespace Tailviewer.Core.Sources.Text.Streaming
 			return true;
 		}
 
-		private void Clear()
-		{
-			lock (_index)
-			{
-				_index.Clear();
-			}
-			_propertiesBuffer.SetValue(GeneralProperties.PercentageProcessed, Percentage.Zero);
-			UpdateLineCount(0);
-		}
-
 		private void AddFirstLineIfNecessary(FileStream stream)
 		{
 			if (stream.Length <= 0)
@@ -410,10 +400,20 @@ namespace Tailviewer.Core.Sources.Text.Streaming
 				count = _index.Count;
 			}
 
-			_propertiesBuffer.SetValue(TextProperties.LineCount, count);
-			_propertiesBuffer.SetValue(GeneralProperties.LogEntryCount, count);
+			UpdateLineCount(count);
+		}
+
+		private void Clear()
+		{
+			lock (_index)
+			{
+				_index.Clear();
+			}
+			_propertiesBuffer.SetValue(GeneralProperties.PercentageProcessed, Percentage.Zero);
+			_propertiesBuffer.SetValue(TextProperties.LineCount, 0);
+			_propertiesBuffer.SetValue(GeneralProperties.LogEntryCount, 0);
 			SynchronizeProperties();
-			_listeners.OnRead(count);
+			_listeners.Reset();
 		}
 
 		private void UpdateLineCount(int count)

--- a/src/Tailviewer.Test/BusinessLogic/Searches/LogSourceSearchTest.cs
+++ b/src/Tailviewer.Test/BusinessLogic/Searches/LogSourceSearchTest.cs
@@ -127,6 +127,7 @@ namespace Tailviewer.Test.BusinessLogic.Searches
 		}
 
 		[Test]
+		[Issue("https://github.com/Kittyfisto/Tailviewer/issues/288")]
 		[Description("Verifies that the search handles a complete invalidation of the log source correctly")]
 		public void TestInvalidate2()
 		{

--- a/src/Tailviewer.Test/BusinessLogic/Searches/LogSourceSearchTest.cs
+++ b/src/Tailviewer.Test/BusinessLogic/Searches/LogSourceSearchTest.cs
@@ -103,5 +103,69 @@ namespace Tailviewer.Test.BusinessLogic.Searches
 					});
 			}
 		}
+
+		[Test]
+		[Description("Verifies that the search handles a partial invalidation of the log source correctly")]
+		public void TestInvalidate1()
+		{
+			var logFile = new InMemoryLogSource();
+			logFile.AddEntry("What's up people?");
+			logFile.AddEntry("Hello World!");
+			logFile.AddEntry("Looks like a bug");
+			using (var search = new LogSourceSearch(_scheduler, logFile, "l", TimeSpan.Zero))
+			{
+				_scheduler.RunOnce();
+				search.Matches.Should().HaveCount(6);
+
+				logFile.RemoveFrom(1);
+				search.Matches.Should().HaveCount(6);
+
+				_scheduler.RunOnce();
+				search.Matches.Should().HaveCount(1, "because we've removed the second and third line, thus removing 5 of the 6 hits in the log source");
+				search.Matches.Should().Equal(new LogMatch(0, new LogLineMatch(14, 1)));
+			}
+		}
+
+		[Test]
+		[Description("Verifies that the search handles a complete invalidation of the log source correctly")]
+		public void TestInvalidate2()
+		{
+			var logFile = new InMemoryLogSource();
+			logFile.AddEntry("What's up people?");
+			logFile.AddEntry("Hello World!");
+			logFile.AddEntry("Looks like a bug");
+			using (var search = new LogSourceSearch(_scheduler, logFile, "l", TimeSpan.Zero))
+			{
+				_scheduler.RunOnce();
+				search.Matches.Should().HaveCount(6);
+
+				logFile.RemoveFrom(0);
+				search.Matches.Should().HaveCount(6);
+
+				_scheduler.RunOnce();
+				search.Matches.Should().HaveCount(0, "because we've removed all lines");
+			}
+		}
+
+		[Test]
+		[Description("Verifies that the search handles a Reset of the log source correctly")]
+		public void TestReset()
+		{
+			var logFile = new InMemoryLogSource();
+			logFile.AddEntry("What's up people?");
+			logFile.AddEntry("Hello World!");
+			logFile.AddEntry("Looks like a bug");
+			using (var search = new LogSourceSearch(_scheduler, logFile, "l", TimeSpan.Zero))
+			{
+				_scheduler.RunOnce();
+				search.Matches.Should().HaveCount(6);
+
+				logFile.Clear();
+				search.Matches.Should().HaveCount(6);
+
+				_scheduler.RunOnce();
+				search.Matches.Should().HaveCount(0, "because we've cleared the log source");
+			}
+		}
 	}
 }

--- a/src/Tailviewer.Test/BusinessLogic/Sources/Merged/MergedLogFileIndexTest.cs
+++ b/src/Tailviewer.Test/BusinessLogic/Sources/Merged/MergedLogFileIndexTest.cs
@@ -346,8 +346,11 @@ namespace Tailviewer.Test.BusinessLogic.Sources.Merged
 			});
 			index.Count.Should().Be(3);
 			index[0].SourceId.Should().Be(1);
+			index[0].MergedLogEntryIndex.Should().Be(0);
 			index[1].SourceId.Should().Be(0);
+			index[1].MergedLogEntryIndex.Should().Be(1);
 			index[2].SourceId.Should().Be(1);
+			index[2].MergedLogEntryIndex.Should().Be(2);
 
 
 			changes = index.Process(new MergedLogSourcePendingModification(source1, LogFileSection.Reset));
@@ -358,11 +361,12 @@ namespace Tailviewer.Test.BusinessLogic.Sources.Merged
 			});
 			index.Count.Should().Be(2);
 			index[0].SourceId.Should().Be(1);
+			index[0].MergedLogEntryIndex.Should().Be(0);
 			index[1].SourceId.Should().Be(1);
+			index[1].MergedLogEntryIndex.Should().Be(1);
 		}
 
 		[Test]
-		[Ignore("This just isn't implemented yet")]
 		[Issue("https://github.com/Kittyfisto/Tailviewer/issues/288")]
 		public void TestTwoSourcesAppendBothInvalidateOne()
 		{
@@ -384,16 +388,20 @@ namespace Tailviewer.Test.BusinessLogic.Sources.Merged
 			});
 			index.Count.Should().Be(4);
 			index[0].SourceId.Should().Be(1);
+			index[0].MergedLogEntryIndex.Should().Be(0);
 			index[1].SourceId.Should().Be(1);
+			index[1].MergedLogEntryIndex.Should().Be(1);
 			index[2].SourceId.Should().Be(0);
+			index[2].MergedLogEntryIndex.Should().Be(2);
 			index[3].SourceId.Should().Be(1);
+			index[3].MergedLogEntryIndex.Should().Be(3);
 
 
 			changes = index.Process(new MergedLogSourcePendingModification(source2, LogFileSection.Invalidate(1, 2)));
 			changes.Should().Equal(new object[]
 			{
 				LogFileSection.Invalidate(1, 3),
-				new LogFileSection(1, 2)
+				new LogFileSection(1, 1)
 			});
 			index.Count.Should().Be(2);
 			index[0].SourceId.Should().Be(1);


### PR DESCRIPTION
Fixes #288

- [x] Fixed bug where StreamingTextLogSource wouldn't fire the Reset event when a log source was resized to a smaller size
- [x] Fixed bug where LogSourceSearch wouldn't properly react to invalidations #288
- [x] Fixed bug where MergedLogSource was dealing correctly with Resets #288
- [x] Fixed bug where MergedLogSource was dealing correctly with invalidations #288