### PR TITLE
Reduced maximum log size to 10MB

### DIFF
--- a/src/Tailviewer/Bootstrapper.cs
+++ b/src/Tailviewer/Bootstrapper.cs
@@ -113,7 +113,7 @@ namespace Tailviewer
 					File = Constants.ApplicationLogFile,
 					Layout = patternLayout,
 					MaxSizeRollBackups = 20,
-					MaximumFileSize = "1GB",
+					MaximumFileSize = "10MB",
 					RollingStyle = RollingFileAppender.RollingMode.Size,
 					StaticLogFileName = false
 				};
@@ -123,10 +123,10 @@ namespace Tailviewer
 			//SetLogLevelOf<MergedLogFile>(Level.Debug);
 			//SetLogLevelOf<MergedLogFileIndex>(Level.Debug);
 			//SetLogLevelOf<LogFileProxy>(Level.Debug);
-			SetLogLevelOf<StreamingTextLogSource>(Level.Debug);
-			SetLogLevelOf<StreamingTextLogSource.AbstractReadRequest>(Level.Debug);
-			SetLogLevelOf<TextCanvas>(Level.Debug);
-			SetLogLevelOf<PageBufferedLogSource>(Level.Debug);
+			//SetLogLevelOf<StreamingTextLogSource>(Level.Debug);
+			//SetLogLevelOf<StreamingTextLogSource.AbstractReadRequest>(Level.Debug);
+			//SetLogLevelOf<TextCanvas>(Level.Debug);
+			//SetLogLevelOf<PageBufferedLogSource>(Level.Debug);
 
 			hierarchy.Root.Level = Level.Info;
 			hierarchy.Configured = true;


### PR DESCRIPTION
Changes proposed in this pull request:
- Previously, each log file grew to a maximum of 1GB. 
- Also, tailviewer logged far too detailed for a release (it was only ever meant to debug a particular issue).


Any expected problems concerning backwards compatibility of existing plugins?  
No

Any expected problems concerning backwards compatibility of existing user settings?  
No

Does this break existing user workflows?  
No
