### PR TITLE
Fixed empty message not appearing after a restart

### DIFF
--- a/src/Tailviewer.Acceptance.Tests/BusinessLogic/Sources/Text/FileLogSourceTest.cs
+++ b/src/Tailviewer.Acceptance.Tests/BusinessLogic/Sources/Text/FileLogSourceTest.cs
@@ -61,6 +61,18 @@ namespace Tailviewer.Acceptance.Tests.BusinessLogic.Sources.Text
 		}
 
 		[Test]
+		public void TestFileDoesNotExist()
+		{
+			var fileName = GetUniqueNonExistingFileName();
+
+			var source = Create(fileName);
+			_taskScheduler.Run(5);
+
+			source.GetProperty(Properties.EmptyReason).Should().BeOfType<SourceDoesNotExist>();
+			source.GetProperty(Properties.Created).Should().Be(null);
+		}
+
+		[Test]
 		public void TestFileCannotBeAccessed()
 		{
 			var fileName = GetUniqueNonExistingFileName();

--- a/src/Tailviewer.Core/Sources/Text/FileLogSource.cs
+++ b/src/Tailviewer.Core/Sources/Text/FileLogSource.cs
@@ -54,6 +54,7 @@ namespace Tailviewer.Core
 		private int _count;
 		private FileFingerprint _lastFingerprint;
 		private int _maxCharactersInLine;
+		private bool _anyChange;
 
 		#endregion
 
@@ -315,6 +316,20 @@ namespace Tailviewer.Core
 					return true;
 				}
 
+				if (!_anyChange)
+				{
+					// We haven't detected any change (i.e. we're within the first loop of this source) and the
+					// file doesn't exist. We want our code to run through at least one loop so that EmptyReason, etc...
+					// are filled correctly. We do this by returning "true" (=a change occurred) ONCE and then no more until
+					// we find an actual change...
+					Log.DebugFormat("File {0} does not exist", _fullFilename);
+
+					_anyChange = true;
+ 
+					return true;
+				}
+
+				// We don't have a fingerprint, which means that th
 				return false;
 			}
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Tailviewer didn't show any reason why a data source was empty, if the data source did not exist from the start


Any expected problems concerning backwards compatibility of existing plugins?  
No

Any expected problems concerning backwards compatibility of existing user settings?  
No

Does this break existing user workflows?  
No
