### PR TITLE
Build scripts create portable archive

### DIFF
--- a/scripts/rename_installer.cmd
+++ b/scripts/rename_installer.cmd
@@ -22,7 +22,7 @@ if [%BRANCH_NAME%] == [master] (
 	set dest_portable_name=Tailviewer-portable-%APPVEYOR_BUILD_VERSION%.zip
 	set dest_installer_name=Tailviewer-setup-%APPVEYOR_BUILD_VERSION%.exe
 ) else (
-	set dest_portable_name=Tailviewer-setup-branch-%BRANCH_NAME%-%COMMIT_HASH%.zip
+	set dest_portable_name=Tailviewer-portable-%BRANCH_NAME%-%COMMIT_HASH%.zip
 	set dest_installer_name=Tailviewer-setup-branch-%BRANCH_NAME%-%COMMIT_HASH%.exe
 )
 

--- a/scripts/rename_installer.cmd
+++ b/scripts/rename_installer.cmd
@@ -22,7 +22,7 @@ if [%BRANCH_NAME%] == [master] (
 	set dest_portable_name=Tailviewer-portable-%APPVEYOR_BUILD_VERSION%.zip
 	set dest_installer_name=Tailviewer-setup-%APPVEYOR_BUILD_VERSION%.exe
 ) else (
-	set dest_portable_name=Tailviewer-portable-%BRANCH_NAME%-%COMMIT_HASH%.zip
+	set dest_portable_name=Tailviewer-portable-branch-%BRANCH_NAME%-%COMMIT_HASH%.zip
 	set dest_installer_name=Tailviewer-setup-branch-%BRANCH_NAME%-%COMMIT_HASH%.exe
 )
 

--- a/scripts/rename_installer.cmd
+++ b/scripts/rename_installer.cmd
@@ -34,7 +34,7 @@ call "%dest_installer_name%" silentinstall || goto :INSTALLATION_FAILED
 echo Installation succeeded!
 
 set install_directory=%PROGRAMFILES%\Tailviewer
-set portable_full_name="%cd%\%dest_portable_name%
+set portable_full_name=%cd%\%dest_portable_name%
 echo Creating portable version from %install_directory% to %portable_full_name%
 tar -a -cvf "%portable_full_name%" -C "%install_directory%" * || goto :PORTABLE_FAILED
 echo Successfully created portable archive!

--- a/scripts/rename_installer.cmd
+++ b/scripts/rename_installer.cmd
@@ -19,24 +19,25 @@ SET source_installer_name="Tailviewer-setup.exe"
 
 if [%BRANCH_NAME%] == [master] (
 	if [%APPVEYOR_BUILD_VERSION%] == [] goto :NO_VERSION
-	set dest_portable_name="Tailviewer-portable-%APPVEYOR_BUILD_VERSION%.zip"
-	set dest_installer_name="Tailviewer-setup-%APPVEYOR_BUILD_VERSION%.exe"
+	set dest_portable_name=Tailviewer-portable-%APPVEYOR_BUILD_VERSION%.zip
+	set dest_installer_name=Tailviewer-setup-%APPVEYOR_BUILD_VERSION%.exe
 ) else (
-	set dest_portable_name="Tailviewer-setup-branch-%BRANCH_NAME%-%COMMIT_HASH%.zip"
-	set dest_installer_name="Tailviewer-setup-branch-%BRANCH_NAME%-%COMMIT_HASH%.exe"
+	set dest_portable_name=Tailviewer-setup-branch-%BRANCH_NAME%-%COMMIT_HASH%.zip
+	set dest_installer_name=Tailviewer-setup-branch-%BRANCH_NAME%-%COMMIT_HASH%.exe
 )
 
 echo Renaming installer to %dest_installer_name%
-ren %source_installer_name% %dest_installer_name% || goto :MOVE_ERROR
+ren %source_installer_name% "%dest_installer_name%" || goto :MOVE_ERROR
 
 echo Executing installer silently....
-call %dest_installer_name% silentinstall || goto :INSTALLATION_FAILED
+call "%dest_installer_name%" silentinstall || goto :INSTALLATION_FAILED
 echo Installation succeeded!
 
 set install_directory=%PROGRAMFILES%\Tailviewer
 set portable_full_name="%cd%\%dest_portable_name%
 echo Creating portable version from %install_directory% to %portable_full_name%
 tar -a -cvf "%portable_full_name%" -C "%install_directory%" * || goto :PORTABLE_FAILED
+echo Successfully created portable archive!
 
 exit /b 0
 

--- a/scripts/rename_installer.cmd
+++ b/scripts/rename_installer.cmd
@@ -19,13 +19,24 @@ SET source_installer_name="Tailviewer-setup.exe"
 
 if [%BRANCH_NAME%] == [master] (
 	if [%APPVEYOR_BUILD_VERSION%] == [] goto :NO_VERSION
-	SET dest_installer_name="Tailviewer-setup-%APPVEYOR_BUILD_VERSION%.exe"
+	set dest_portable_name="Tailviewer-portable-%APPVEYOR_BUILD_VERSION%.zip"
+	set dest_installer_name="Tailviewer-setup-%APPVEYOR_BUILD_VERSION%.exe"
 ) else (
-	SET dest_installer_name="Tailviewer-setup-branch-%BRANCH_NAME%-%COMMIT_HASH%.exe"
+	set dest_portable_name="Tailviewer-setup-branch-%BRANCH_NAME%-%COMMIT_HASH%.zip"
+	set dest_installer_name="Tailviewer-setup-branch-%BRANCH_NAME%-%COMMIT_HASH%.exe"
 )
 
 echo Renaming installer to %dest_installer_name%
 ren %source_installer_name% %dest_installer_name% || goto :MOVE_ERROR
+
+echo Executing installer silently....
+call %dest_installer_name% silentinstall || goto :INSTALLATION_FAILED
+echo Installation succeeded!
+
+set install_directory=%PROGRAMFILES%\Tailviewer
+echo Creating portable version from %install_directory%
+tar -a -cvf %dest_portable_name% -C "%install_directory%" * || goto :PORTABLE_FAILED
+
 exit /b 0
 
 :NO_VERSION
@@ -35,5 +46,13 @@ exit /b -1
 :MOVE_ERROR
 echo ERROR: Unable to rename installer, ren returned %errorlevel%
 exit /b -2
+
+:INSTALLATION_FAILED
+echo ERROR: Installation failed, setup returned %errorlevel%
+exit /b -3
+
+:PORTABLE_FAILED
+echo ERROR: Creating zip archive from installation failed, tar returned %errorlevel% 
+exit /b -4
 
 endlocal

--- a/scripts/rename_installer.cmd
+++ b/scripts/rename_installer.cmd
@@ -34,8 +34,9 @@ call %dest_installer_name% silentinstall || goto :INSTALLATION_FAILED
 echo Installation succeeded!
 
 set install_directory=%PROGRAMFILES%\Tailviewer
-echo Creating portable version from %install_directory%
-tar -a -cvf %dest_portable_name% -C "%install_directory%" * || goto :PORTABLE_FAILED
+set portable_full_name="%cd%\%dest_portable_name%
+echo Creating portable version from %install_directory% to %portable_full_name%
+tar -a -cvf "%portable_full_name%" -C "%install_directory%" * || goto :PORTABLE_FAILED
 
 exit /b 0
 


### PR DESCRIPTION
Every Tailviewer build (both mainline and MRs) creates a "portable" version which is merely a zipped version of the installation folder under "%PROGRAMFILES%\Tailviewer". This version should be executable directly from a USB drive since it doesn't write to the installation directory.  

However there is still the major drawback that the computer needs to have .NET 4.7.1 installed, which is why this isn't a truly portable version. That will be addressed once Tailviewer has been ported to >= .NET 5.

See #355

Any expected problems concerning backwards compatibility of existing plugins?  
No

Any expected problems concerning backwards compatibility of existing user settings?  
No

Does this break existing user workflows?  
No
