### PR TITLE
Add support for timestamp format "HH:mm:ss,fff"

### DIFF
--- a/src/Tailviewer.Core.Tests/Parsers/TimestampParserTest.cs
+++ b/src/Tailviewer.Core.Tests/Parsers/TimestampParserTest.cs
@@ -237,6 +237,21 @@ namespace Tailviewer.Core.Tests.Parsers
 		}
 
 		[Test]
+		public void TestTryParse14()
+		{
+			var parser = new TimestampParser();
+			parser.TryParse("19:50:58,998",
+			                out var dateTime)
+			      .Should()
+			      .BeTrue();
+
+			dateTime.Hour.Should().Be(19);
+			dateTime.Minute.Should().Be(50);
+			dateTime.Second.Should().Be(58);
+			dateTime.Millisecond.Should().Be(998);
+		}
+
+		[Test]
 		public void TestTryParseLongGarbageLine()
 		{
 			var parser = new TimestampParser();

--- a/src/Tailviewer.Core/Parsers/TimestampParser.cs
+++ b/src/Tailviewer.Core/Parsers/TimestampParser.cs
@@ -70,6 +70,8 @@ namespace Tailviewer.Core
 				// One of the most bizare formats: Time of day is apparently not interesting enough, just as are fractions of a second.
 				// We do, however, get the seconds (in nano seconds) since the start of the application...
 				new TimeOfDaySecondsSinceStartParser(),
+				
+				new DateTimeParser("HH:mm:ss,fff"),
 				new DateTimeParser("HH:mm:ss.fff"),
 				new DateTimeParser("HH:mm:ss")
 			)


### PR DESCRIPTION
Changes proposed in this pull request:
- Add support for timestamps in format HH:mm:ss,fff

Rationale: timestamps with a dot as decimal separator (HH:mm:ss.fff) are already supported. However, in [ISO8601](https://www.loc.gov/standards/datetime/iso-tc154-wg5_n0038_iso_wd_8601-1_2016-02-16.pdf), the comma is the recommended decimal separator:

> [...]  the	 decimal	fraction	shall	be	divided	from	the	integer	part	by	the	decimal	sign	specified	in	ISO 31-0,	i.e.	the	comma	[,]	or	full	stop	[.].	Of	these,	the	comma	is	the	preferred	sign.

Our software uses HH:mm:ss,fff today and we would prefer keeping this format since it's recommended by ISO rather than changing it for compatibility with Tailviewer.

Any expected problems concerning backwards compatibility of existing plugins?  
No

Any expected problems concerning backwards compatibility of existing user settings?  
No

Does this break existing user workflows?  
No
